### PR TITLE
Remove duplicate "HSSI" next to logo in title

### DIFF
--- a/django/hssi/templates/site_base_template.html
+++ b/django/hssi/templates/site_base_template.html
@@ -101,7 +101,7 @@
 		</div>
 		<div class="site_name">
 			<a href="{{SITE_PROTOCOL}}://{{SITE_DOMAIN}}/">
-				HSSI - Heliophysics Software Search Interface<br>
+				Heliophysics Software Search Interface<br>
 			</a>
 		</div>
 	</div>


### PR DESCRIPTION
Hopefully I did this in the right file. I didn't actually spin up the website locally to confirm (sorry) but it was the only place in the repo that `"HSSI - Heliophysics Software Search Interface"` existed so I'm pretty confident.