### PR TITLE
Fix organization name parsing when stripping abbreviations

### DIFF
--- a/django/website/data_parser.py
+++ b/django/website/data_parser.py
@@ -236,7 +236,7 @@ def parse_organization(
 		elif allow_creation:
 			organization = Organization()
 			org_abbrev_match = PARENTHESIS_MATCH.findall(org_name)
-			org_name = PARENTHESIS_MATCH.sub(org_name, "")
+			org_name = PARENTHESIS_MATCH.sub("", org_name).strip()
 			organization.name = org_name
 
 			# infer abbreviation from parenthesis


### PR DESCRIPTION
## Summary
- fix organization name cleanup in `parse_organization` so parenthetical abbreviations are removed correctly
- avoid blank organization names when creating funder/publisher/org records from submission payloads

## Root cause
`re.Pattern.sub` arguments were reversed:
- before: `PARENTHESIS_MATCH.sub(org_name, "")`
- after: `PARENTHESIS_MATCH.sub("", org_name).strip()`

With the old call order, simple names like `NSF` and `DARPA` could become empty strings, causing degraded funder organization records.

## Validation
- reproduced the failure with direct regex behavior check
- confirmed corrected behavior for `NSF`, `DARPA`, and names with parenthetical abbreviations like `NASA (HQ)`
