### PR TITLE
Link software detail badges to filtered homepage view

### DIFF
--- a/django/website/models/base.py
+++ b/django/website/models/base.py
@@ -261,13 +261,25 @@ class ControlledList(HssiModel):
 
 	def get_tooltip(self): return self.definition
 
+	homepage_filter_field: str | None = None
+
+	def get_homepage_filter_url(self) -> str | None:
+		if self.homepage_filter_field is None:
+			return None
+		from django.urls import reverse
+		return (
+			reverse("website:published_resources")
+			+ "?"
+			+ build_software_filter_query(self.homepage_filter_field, self.id)
+		)
+
 	def get_search_terms(self) -> list[str]:
 		return [
 			*self.name
 				.replace(',',' ')
 				.replace(';',' ')
 				.replace(':',' ')
-				.split(), 
+				.split(),
 			self.identifier if self.identifier else '',
 		]
 

--- a/django/website/models/vocab.py
+++ b/django/website/models/vocab.py
@@ -84,6 +84,14 @@ class DataInput(ControlledList):
 	access = AccessLevel.PUBLIC
 	abbreviation = models.CharField(max_length=LEN_ABBREVIATION, blank=True, null=True)
 
+	def get_homepage_filter_url(self) -> str:
+		from django.urls import reverse
+		return (
+			reverse("website:published_resources")
+			+ "?"
+			+ build_software_filter_query("data_sources", self.id)
+		)
+
 	def __str__(self): return self.name
 
 class FileFormat(ControlledList):

--- a/django/website/models/vocab.py
+++ b/django/website/models/vocab.py
@@ -219,6 +219,14 @@ class Region(ControlledGraphList):
 		symmetrical=False,
 	)
 
+	def get_homepage_filter_url(self) -> str:
+		from django.urls import reverse
+		return (
+			reverse("website:published_resources")
+			+ "?"
+			+ build_software_filter_query("related_region", self.id)
+		)
+
 	@classmethod
 	def post_fetch(cls):
 

--- a/django/website/models/vocab.py
+++ b/django/website/models/vocab.py
@@ -67,30 +67,16 @@ class RepoStatus(ControlledList):
 class ProgrammingLanguage(ControlledList):
 	"""Primary Programming language used to develop the software"""
 	access = AccessLevel.PUBLIC
+	homepage_filter_field = "programming_language"
 	version = models.CharField(max_length=LEN_NAME, blank=True, null=True)
-
-	def get_homepage_filter_url(self) -> str:
-		from django.urls import reverse
-		return (
-			reverse("website:published_resources")
-			+ "?"
-			+ build_software_filter_query("programming_language", self.id)
-		)
 
 	def __str__(self): return self.name + (f" {self.version}" if self.version else "")
 
 class DataInput(ControlledList):
 	"""Ways that the software can accept data as input"""
 	access = AccessLevel.PUBLIC
+	homepage_filter_field = "data_sources"
 	abbreviation = models.CharField(max_length=LEN_ABBREVIATION, blank=True, null=True)
-
-	def get_homepage_filter_url(self) -> str:
-		from django.urls import reverse
-		return (
-			reverse("website:published_resources")
-			+ "?"
-			+ build_software_filter_query("data_sources", self.id)
-		)
 
 	def __str__(self): return self.name
 
@@ -124,6 +110,7 @@ class InstrumentObservatory(ControlledList):
 
 class FunctionCategory(ControlledGraphList):
 	access = AccessLevel.PUBLIC
+	homepage_filter_field = "software_functionality"
 	abbreviation = models.CharField(max_length=5, null=True, blank=True)
 	backgroundColor = RGBColorField("Background Color", default="#FFFFFF", blank=True, null=True)
 	textColor = RGBColorField("Text Color", default="#000000", blank=True, null=True)
@@ -149,14 +136,6 @@ class FunctionCategory(ControlledGraphList):
 			choice_name,
 			self.get_search_terms(),
 			self.get_tooltip(),
-		)
-
-	def get_homepage_filter_url(self) -> str:
-		from django.urls import reverse
-		return (
-			reverse("website:published_resources")
-			+ "?"
-			+ build_software_filter_query("software_functionality", self.id)
 		)
 
 	@classmethod
@@ -219,21 +198,14 @@ class FunctionCategory(ControlledGraphList):
 class Region(ControlledGraphList):
 	"""Region of the sun which relates to the software"""
 	access = AccessLevel.PUBLIC
-	
+	homepage_filter_field = "related_region"
+
 	children = models.ManyToManyField(
 		'self',
 		blank=True,
 		related_name='parent_nodes',
 		symmetrical=False,
 	)
-
-	def get_homepage_filter_url(self) -> str:
-		from django.urls import reverse
-		return (
-			reverse("website:published_resources")
-			+ "?"
-			+ build_software_filter_query("related_region", self.id)
-		)
 
 	@classmethod
 	def post_fetch(cls):

--- a/django/website/models/vocab.py
+++ b/django/website/models/vocab.py
@@ -135,6 +135,14 @@ class FunctionCategory(ControlledGraphList):
 			self.get_tooltip(),
 		)
 
+	def get_homepage_filter_url(self) -> str:
+		from django.urls import reverse
+		return (
+			reverse("website:published_resources")
+			+ "?"
+			+ build_software_filter_query("software_functionality", self.id)
+		)
+
 	@classmethod
 	def post_fetch(cls):
 		super().post_fetch()

--- a/django/website/models/vocab.py
+++ b/django/website/models/vocab.py
@@ -69,6 +69,14 @@ class ProgrammingLanguage(ControlledList):
 	access = AccessLevel.PUBLIC
 	version = models.CharField(max_length=LEN_NAME, blank=True, null=True)
 
+	def get_homepage_filter_url(self) -> str:
+		from django.urls import reverse
+		return (
+			reverse("website:published_resources")
+			+ "?"
+			+ build_software_filter_query("programming_language", self.id)
+		)
+
 	def __str__(self): return self.name + (f" {self.version}" if self.version else "")
 
 class DataInput(ControlledList):

--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -208,10 +208,13 @@
             <summary class="section-title">Functionality</summary>
             <div class="functionality-tags">
                 {% for func in software.software_functionality.all %}
-                <span class="tag functionality-tag"
-                      style="background-color: {{ func.backgroundColor }}; color: {{ func.textColor }}">
+                <a href="{{ func.get_homepage_filter_url }}"
+                   class="tag functionality-tag"
+                   title="View software filtered by {{ func.name }}"
+                   aria-label="View software filtered by {{ func.name }}"
+                   style="background-color: {{ func.backgroundColor }}; color: {{ func.textColor }}">
                     {{ func.name }}
-                </span>
+                </a>
                 {% endfor %}
             </div>
         </details>

--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -229,7 +229,10 @@
                     <span class="metadata-label">Programming Languages</span>
                     <span class="metadata-value">
                         {% for lang in software.programming_language.all %}
-                        <span class="tag">{{ lang.name }}</span>
+                        <a href="{{ lang.get_homepage_filter_url }}"
+                           class="tag"
+                           title="View software filtered by {{ lang.name }}"
+                           aria-label="View software filtered by {{ lang.name }}">{{ lang.name }}</a>
                         {% endfor %}
                     </span>
                 </div>

--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -407,17 +407,16 @@
                     <span class="metadata-label">Related Regions</span>
                     <span class="metadata-value">
                         {% for reg in software.related_region.all %}
-                        {% if reg.identifier %}
-                        <a class="tag" href="{{ reg.identifier }}" target="_blank">
+                        <a href="{{ reg.get_homepage_filter_url }}"
+                           class="tag"
+                           title="View software filtered by {{ reg.name }}"
+                           aria-label="View software filtered by {{ reg.name }}">
                             {% if reg.name and reg.name != "UNKNOWN" %}
                             {{ reg.name }}
                             {% else %}
                             {{ reg.identifier }}
                             {% endif %}
                         </a>
-                        {% else %}
-                        <span class="tag">{{ reg.name }}</span>
-                        {% endif %}
                         {% endfor %}
                     </span>
                 </div>

--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -303,7 +303,10 @@
                     <span class="metadata-label">Data Sources</span>
                     <span class="metadata-value">
                         {% for ds in software.data_sources.all %}
-                        <span class="tag">{{ ds.name }}</span>
+                        <a href="{{ ds.get_homepage_filter_url }}"
+                           class="tag"
+                           title="View software filtered by {{ ds.name }}"
+                           aria-label="View software filtered by {{ ds.name }}">{{ ds.name }}</a>
                         {% endfor %}
                     </span>
                 </div>

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -2,11 +2,28 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from .models import FunctionCategory
+from .models import FunctionCategory, ProgrammingLanguage
 from .util import build_software_filter_query, shorten_software_filter_value
 
 
 class SoftwareFilterEncodingTests(SimpleTestCase):
+	def test_programming_language_token_matches_frontend_encoding(self):
+		language_id = uuid.UUID("1b6ddaa6-6885-46b3-b59a-ea119e61bd74")
+		self.assertEqual(
+			shorten_software_filter_value("programming_language", language_id),
+			"G23apmip",
+		)
+
+	def test_programming_language_homepage_filter_url(self):
+		language = ProgrammingLanguage(
+			id=uuid.UUID("1b6ddaa6-6885-46b3-b59a-ea119e61bd74"),
+			name="Python 3.x",
+		)
+		self.assertEqual(
+			language.get_homepage_filter_url(),
+			f"/?{build_software_filter_query('programming_language', language.id)}",
+		)
+
 	def test_software_functionality_token_matches_frontend_encoding(self):
 		func_id = uuid.UUID("332b6567-bdd1-4132-a0c5-532e78b5538c")
 		self.assertEqual(

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -5,72 +5,28 @@ from django.test import SimpleTestCase
 from .models import DataInput, FunctionCategory, ProgrammingLanguage, Region
 from .util import build_software_filter_query, shorten_software_filter_value
 
+FILTER_CASES = [
+	("data_sources",           DataInput,            "a1f8de3a-1bde-4995-94e5-e88e841a62a6", "ofjeOhvds"),
+	("related_region",         Region,               "b450b02c-ac3e-466e-b3a1-70040b169562", "tFCwLKwr"),
+	("programming_language",   ProgrammingLanguage,  "1b6ddaa6-6885-46b3-b59a-ea119e61bd74", "G23apmip"),
+	("software_functionality", FunctionCategory,     "332b6567-bdd1-4132-a0c5-532e78b5538c", "MytlZ73f"),
+]
+
 
 class SoftwareFilterEncodingTests(SimpleTestCase):
-	def test_data_source_token_matches_frontend_encoding(self):
-		data_source_id = uuid.UUID("a1f8de3a-1bde-4995-94e5-e88e841a62a6")
-		self.assertEqual(
-			shorten_software_filter_value("data_sources", data_source_id),
-			"ofjeOhvds",
-		)
+	def test_tokens_match_frontend_encoding(self):
+		for field, _, uid_str, expected_token in FILTER_CASES:
+			with self.subTest(field=field):
+				self.assertEqual(
+					shorten_software_filter_value(field, uuid.UUID(uid_str)),
+					expected_token,
+				)
 
-	def test_data_source_homepage_filter_url(self):
-		data_source = DataInput(
-			id=uuid.UUID("a1f8de3a-1bde-4995-94e5-e88e841a62a6"),
-			name="HAPI",
-		)
-		self.assertEqual(
-			data_source.get_homepage_filter_url(),
-			f"/?{build_software_filter_query('data_sources', data_source.id)}",
-		)
-
-	def test_region_token_matches_frontend_encoding(self):
-		region_id = uuid.UUID("b450b02c-ac3e-466e-b3a1-70040b169562")
-		self.assertEqual(
-			shorten_software_filter_value("related_region", region_id),
-			"tFCwLKwr",
-		)
-
-	def test_region_homepage_filter_url(self):
-		region = Region(
-			id=uuid.UUID("b450b02c-ac3e-466e-b3a1-70040b169562"),
-			name="Earth Magnetosphere",
-		)
-		self.assertEqual(
-			region.get_homepage_filter_url(),
-			f"/?{build_software_filter_query('related_region', region.id)}",
-		)
-
-	def test_programming_language_token_matches_frontend_encoding(self):
-		language_id = uuid.UUID("1b6ddaa6-6885-46b3-b59a-ea119e61bd74")
-		self.assertEqual(
-			shorten_software_filter_value("programming_language", language_id),
-			"G23apmip",
-		)
-
-	def test_programming_language_homepage_filter_url(self):
-		language = ProgrammingLanguage(
-			id=uuid.UUID("1b6ddaa6-6885-46b3-b59a-ea119e61bd74"),
-			name="Python 3.x",
-		)
-		self.assertEqual(
-			language.get_homepage_filter_url(),
-			f"/?{build_software_filter_query('programming_language', language.id)}",
-		)
-
-	def test_software_functionality_token_matches_frontend_encoding(self):
-		func_id = uuid.UUID("332b6567-bdd1-4132-a0c5-532e78b5538c")
-		self.assertEqual(
-			shorten_software_filter_value("software_functionality", func_id),
-			"MytlZ73f",
-		)
-
-	def test_function_category_homepage_filter_url(self):
-		func = FunctionCategory(
-			id=uuid.UUID("332b6567-bdd1-4132-a0c5-532e78b5538c"),
-			name="Coordinate Transforms",
-		)
-		self.assertEqual(
-			func.get_homepage_filter_url(),
-			f"/?{build_software_filter_query('software_functionality', func.id)}",
-		)
+	def test_homepage_filter_urls(self):
+		for field, model_cls, uid_str, _ in FILTER_CASES:
+			with self.subTest(model=model_cls.__name__):
+				obj = model_cls(id=uuid.UUID(uid_str), name="test")
+				self.assertEqual(
+					obj.get_homepage_filter_url(),
+					f"/?{build_software_filter_query(field, obj.id)}",
+				)

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -2,11 +2,28 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from .models import FunctionCategory, ProgrammingLanguage, Region
+from .models import DataInput, FunctionCategory, ProgrammingLanguage, Region
 from .util import build_software_filter_query, shorten_software_filter_value
 
 
 class SoftwareFilterEncodingTests(SimpleTestCase):
+	def test_data_source_token_matches_frontend_encoding(self):
+		data_source_id = uuid.UUID("a1f8de3a-1bde-4995-94e5-e88e841a62a6")
+		self.assertEqual(
+			shorten_software_filter_value("data_sources", data_source_id),
+			"ofjeOhvds",
+		)
+
+	def test_data_source_homepage_filter_url(self):
+		data_source = DataInput(
+			id=uuid.UUID("a1f8de3a-1bde-4995-94e5-e88e841a62a6"),
+			name="HAPI",
+		)
+		self.assertEqual(
+			data_source.get_homepage_filter_url(),
+			f"/?{build_software_filter_query('data_sources', data_source.id)}",
+		)
+
 	def test_region_token_matches_frontend_encoding(self):
 		region_id = uuid.UUID("b450b02c-ac3e-466e-b3a1-70040b169562")
 		self.assertEqual(

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -2,11 +2,28 @@ import uuid
 
 from django.test import SimpleTestCase
 
-from .models import FunctionCategory, ProgrammingLanguage
+from .models import FunctionCategory, ProgrammingLanguage, Region
 from .util import build_software_filter_query, shorten_software_filter_value
 
 
 class SoftwareFilterEncodingTests(SimpleTestCase):
+	def test_region_token_matches_frontend_encoding(self):
+		region_id = uuid.UUID("b450b02c-ac3e-466e-b3a1-70040b169562")
+		self.assertEqual(
+			shorten_software_filter_value("related_region", region_id),
+			"tFCwLKwr",
+		)
+
+	def test_region_homepage_filter_url(self):
+		region = Region(
+			id=uuid.UUID("b450b02c-ac3e-466e-b3a1-70040b169562"),
+			name="Earth Magnetosphere",
+		)
+		self.assertEqual(
+			region.get_homepage_filter_url(),
+			f"/?{build_software_filter_query('related_region', region.id)}",
+		)
+
 	def test_programming_language_token_matches_frontend_encoding(self):
 		language_id = uuid.UUID("1b6ddaa6-6885-46b3-b59a-ea119e61bd74")
 		self.assertEqual(

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -1,3 +1,25 @@
-from django.test import TestCase
+import uuid
 
-# Create your tests here.
+from django.test import SimpleTestCase
+
+from .models import FunctionCategory
+from .util import build_software_filter_query, shorten_software_filter_value
+
+
+class SoftwareFilterEncodingTests(SimpleTestCase):
+	def test_software_functionality_token_matches_frontend_encoding(self):
+		func_id = uuid.UUID("332b6567-bdd1-4132-a0c5-532e78b5538c")
+		self.assertEqual(
+			shorten_software_filter_value("software_functionality", func_id),
+			"MytlZ73f",
+		)
+
+	def test_function_category_homepage_filter_url(self):
+		func = FunctionCategory(
+			id=uuid.UUID("332b6567-bdd1-4132-a0c5-532e78b5538c"),
+			name="Coordinate Transforms",
+		)
+		self.assertEqual(
+			func.get_homepage_filter_url(),
+			f"/?{build_software_filter_query('software_functionality', func.id)}",
+		)

--- a/django/website/util.py
+++ b/django/website/util.py
@@ -16,6 +16,7 @@ SPACE_REPLACE = re.compile(r'[_\-.]')
 PARENTHESIS_MATCH = re.compile(r"\(([^)]*)\)")
 FILTER_URL_UID_ENCODE_LENGTH = 7
 SOFTWARE_FILTER_FIELD_PARAM_MAP = {
+	"data_sources": "ds",
 	"programming_language": "p",
 	"related_region": "r",
 	"software_functionality": "f",

--- a/django/website/util.py
+++ b/django/website/util.py
@@ -17,6 +17,7 @@ PARENTHESIS_MATCH = re.compile(r"\(([^)]*)\)")
 FILTER_URL_UID_ENCODE_LENGTH = 7
 SOFTWARE_FILTER_FIELD_PARAM_MAP = {
 	"programming_language": "p",
+	"related_region": "r",
 	"software_functionality": "f",
 }
 

--- a/django/website/util.py
+++ b/django/website/util.py
@@ -16,6 +16,7 @@ SPACE_REPLACE = re.compile(r'[_\-.]')
 PARENTHESIS_MATCH = re.compile(r"\(([^)]*)\)")
 FILTER_URL_UID_ENCODE_LENGTH = 7
 SOFTWARE_FILTER_FIELD_PARAM_MAP = {
+	"programming_language": "p",
 	"software_functionality": "f",
 }
 

--- a/django/website/util.py
+++ b/django/website/util.py
@@ -1,4 +1,5 @@
-import re, typing
+import base64, re, typing, uuid
+from urllib.parse import urlencode
 
 from django.contrib.auth.models import AbstractUser, AnonymousUser
 from django.db.models import Model, Manager, ManyToManyField
@@ -13,6 +14,10 @@ if typing.TYPE_CHECKING:
 SOFTWARE_FUNCAT_FILEPATH = "./software_funcat_map.csv"
 SPACE_REPLACE = re.compile(r'[_\-.]')
 PARENTHESIS_MATCH = re.compile(r"\(([^)]*)\)")
+FILTER_URL_UID_ENCODE_LENGTH = 7
+SOFTWARE_FILTER_FIELD_PARAM_MAP = {
+	"software_functionality": "f",
+}
 
 class RequirementLevel(IntEnum):
 	OPTIONAL = 0
@@ -59,6 +64,23 @@ def name_to_abbreviation(name: str) -> str:
 			splname[-1][0].upper()
 		)
 	return name
+
+def uuid_to_urlsafe_base64(uid: str | uuid.UUID) -> str:
+	"""Match the frontend UUID -> URL-safe base64 encoding."""
+	return base64.urlsafe_b64encode(uuid.UUID(str(uid)).bytes).decode().rstrip("=")
+
+def shorten_software_filter_value(field_name: str, uid: str | uuid.UUID) -> str:
+	"""Match frontend filter encoding in frontend/filters/urlEncoding.ts."""
+	try:
+		field_suffix = SOFTWARE_FILTER_FIELD_PARAM_MAP[field_name]
+	except KeyError as exc:
+		raise ValueError(f"Unsupported software filter field: {field_name}") from exc
+	short_uid = uuid_to_urlsafe_base64(uid)[:FILTER_URL_UID_ENCODE_LENGTH]
+	return f"{short_uid}{field_suffix}"
+
+def build_software_filter_query(field_name: str, uid: str | uuid.UUID) -> str:
+	"""Build the query string used by the homepage filter menu."""
+	return urlencode({"filt": shorten_software_filter_value(field_name, uid)})
 
 def find_database_references(object: Model) -> list[tuple[Model, Field]]:
 	"""


### PR DESCRIPTION
## Summary

Badges on Software detail pages that correspond to homepage filter categories are now clickable links. Clicking one navigates to the homepage with that filter pre-applied, so users can quickly discover related software.

**Linked badge types:** Software Functionality, Programming Languages, Data Sources, Related Regions.

## Design decisions

### Server-rendered `href` with mirrored frontend encoding
Rather than adding client-side JS click handlers, each badge is a plain `<a>` tag with a server-rendered URL. The backend mirrors the frontend's deterministic filter-token encoding (base64-shortened UUIDs + field suffix, as defined in `frontend/filters/urlEncoding.ts`). This means:
- Links work without JavaScript
- They are crawlable and shareable
- No new frontend bundle code is needed

### `homepage_filter_field` class attribute on `ControlledList`
All four linked models (`ProgrammingLanguage`, `DataInput`, `FunctionCategory`, `Region`) inherit from `ControlledList`. Instead of duplicating the same `get_homepage_filter_url()` method on each subclass, a single implementation lives on the base class, driven by an opt-in `homepage_filter_field` class attribute. Each subclass declares only the field name it maps to (e.g. `homepage_filter_field = "programming_language"`). Models that don't set it get `None`, so the base method is safe for all subclasses. Adding a new linked badge type in the future requires only one line on the model.

### Python ↔ TypeScript encoding parity, covered by tests
`SOFTWARE_FILTER_FIELD_PARAM_MAP` in `util.py` intentionally duplicates a subset of `softwareFieldParamPairs` from the frontend. This is a deliberate trade-off: the duplication is minimal (4 entries) and avoids cross-language build complexity. Table-driven tests with known UUID → token pairs verify that the Python encoding matches the frontend output, catching any drift.

### Related Regions: filter link replaces external identifier link
Region badges previously linked to an external identifier URL (e.g. SPASE). They now link to the filtered homepage view instead, consistent with the other three badge types. This was an intentional product decision to prioritize in-app discovery over external navigation.

## Changes

- **`django/website/models/base.py`** — Add `homepage_filter_field` attribute and `get_homepage_filter_url()` to `ControlledList`
- **`django/website/models/vocab.py`** — Declare `homepage_filter_field` on `ProgrammingLanguage`, `DataInput`, `FunctionCategory`, `Region`
- **`django/website/util.py`** — Add `build_software_filter_query()`, `shorten_software_filter_value()`, `uuid_to_urlsafe_base64()`, and `SOFTWARE_FILTER_FIELD_PARAM_MAP`
- **`django/website/templates/website/software_detail.html`** — Convert badge `<span>` tags to `<a>` tags with filter URLs; add `title` and `aria-label` for accessibility
- **`django/website/tests.py`** — Table-driven tests verifying encoding parity and URL construction for all four badge types

## Test plan

- [x] Verify each badge type on a software detail page links to the homepage with the correct filter applied
- [x] Confirm the homepage correctly filters results when loaded from a badge link
- [x] Check that non-linked badge types (e.g. keywords) are unaffected
- [x] Run `python manage.py test website` to confirm encoding parity tests pass