### PR TITLE
Fix batch submission queue bug in SubmissionAPI

### DIFF
--- a/django/website/views/api/software_api.py
+++ b/django/website/views/api/software_api.py
@@ -96,7 +96,7 @@ class SubmissionAPI(APIView):
 			return Response(exc.detail, status=status.HTTP_400_BAD_REQUEST)
 		
 		for submission in submissions:
-			SoftwareEditQueue.create(software, timezone.now() + datetime.timedelta(days=90))
+			SoftwareEditQueue.create(submission, timezone.now() + datetime.timedelta(days=90))
 			submission_info = SubmissionInfo.objects.get(software=submission)
 			email_existing_edit_link(submission_info)
 


### PR DESCRIPTION
## Summary

- `SoftwareEditQueue.create()` in `SubmissionAPI.post()` was using the stale `software` variable (last item from the serialization loop) instead of the `submission` loop variable
- For batch submissions with multiple items, this caused all queue entries to point to the last software item instead of creating one per submission
- Single-item submissions were unaffected

## Change

One-line fix in `django/website/views/api/software_api.py` line 99: `software` → `submission`