### PR TITLE
V3 of Update API: Add isolated PATCH /api/data/software/<uid>/ partial update endpoint

### DIFF
--- a/django/hssi/settings.py
+++ b/django/hssi/settings.py
@@ -22,6 +22,10 @@ SECRET_KEY = 'abcdefg'
 SUPERUSER_NAME = None if 'SUPERUSER_NAME' not in os.environ else os.environ.get('SUPERUSER_NAME')
 SUPERUSER_PWD = None if 'SUPERUSER_PWD' not in os.environ else os.environ.get('SUPERUSER_PWD')
 
+# Bearer token required to authenticate PATCH /api/data/software/<uid>/.
+# When unset, the update endpoint denies every request.
+HSSI_UPDATE_TOKEN = os.environ.get("HSSI_UPDATE_TOKEN")
+
 ADMIN_EMAIL = "admin@my-site.com"
 DEFAULT_FROM_EMAIL = "noreply@hssi.hsdcloud.org"
 

--- a/django/website/test_update_api.py
+++ b/django/website/test_update_api.py
@@ -1,0 +1,274 @@
+"""Regression tests for isolated PATCH updates and repository URL lookup."""
+
+import uuid
+
+from django.test import TestCase, override_settings
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from .models import (
+	Keyword,
+	License,
+	RepoStatus,
+	Software,
+	SubmissionInfo,
+	VerifiedSoftware,
+)
+
+
+UPDATE_TOKEN = "test-token-please-ignore"
+
+
+@override_settings(HSSI_UPDATE_TOKEN=UPDATE_TOKEN)
+class SoftwarePartialUpdateTests(TestCase):
+	"""PATCH /api/data/software/<uid>/ behavior."""
+
+	@classmethod
+	def setUpTestData(cls):
+		cls.software = Software.objects.create(
+			software_name="Test Software",
+			code_repository_url="https://example.com/test",
+			description="original",
+			documentation="https://docs.example.com/test",
+		)
+		VerifiedSoftware.create_verified(cls.software)
+		cls.submission_info = SubmissionInfo.objects.create(
+			software=cls.software,
+			submission_date=timezone.now(),
+		)
+		cls.active_status = RepoStatus.objects.create(name="Active")
+		RepoStatus.objects.create(name="Inactive")
+		License.objects.create(name="MIT")
+
+	def setUp(self):
+		self.client = APIClient()
+		self.url = f"/api/data/software/{self.software.id}/"
+		self.auth = f"Bearer {UPDATE_TOKEN}"
+
+	def _patch(self, data, auth: str | None = None):
+		kwargs = {"format": "json"}
+		header = self.auth if auth is None else auth
+		if header:
+			kwargs["HTTP_AUTHORIZATION"] = header
+		return self.client.patch(self.url, data=data, **kwargs)
+
+	def test_scalar_update_sets_fk_field(self):
+		response = self._patch({"developmentStatus": "Active"})
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+		self.software.refresh_from_db()
+		self.assertEqual(self.software.development_status, self.active_status)
+		self.assertIn("development_status", response.data["fieldsUpdated"])
+
+	def test_m2m_replacement_replaces_keywords(self):
+		self.software.keywords.add(Keyword.objects.create(name="old"))
+
+		response = self._patch({"keywords": ["alpha", "beta"]})
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+		names = sorted(self.software.keywords.values_list("name", flat=True))
+		self.assertEqual(names, ["alpha", "beta"])
+
+	def test_empty_list_clears_m2m(self):
+		self.software.keywords.add(Keyword.objects.create(name="old"))
+		self.assertEqual(self.software.keywords.count(), 1)
+
+		response = self._patch({"keywords": []})
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+		self.assertEqual(self.software.keywords.count(), 0)
+
+	def test_missing_field_leaves_value_unchanged(self):
+		response = self._patch({"developmentStatus": "Active"})
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+		self.software.refresh_from_db()
+		self.assertEqual(self.software.description, "original")
+
+	def test_nullable_scalar_can_be_cleared(self):
+		response = self._patch({"documentation": None})
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+		self.software.refresh_from_db()
+		self.assertIsNone(self.software.documentation)
+
+	def test_unknown_field_rejected(self):
+		response = self._patch({"notAField": "value"})
+
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+		self.assertIn("not_a_field", response.data)
+
+	def test_submitter_rejected(self):
+		response = self._patch({
+			"submitter": [{
+				"email": "x@y.com",
+				"person": {"givenName": "A", "familyName": "B"},
+			}],
+		})
+
+		self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+		self.assertIn("submitter", response.data)
+
+	def test_invalid_token_rejected(self):
+		response = self._patch({"developmentStatus": "Active"}, auth="Bearer wrong")
+		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+	def test_missing_token_rejected(self):
+		response = self._patch({"developmentStatus": "Active"}, auth="")
+		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+	def test_malformed_auth_header_rejected(self):
+		response = self._patch({"developmentStatus": "Active"}, auth="Token wrong")
+		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+	def test_updates_modification_description(self):
+		response = self._patch({"developmentStatus": "Active"})
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+		self.submission_info.refresh_from_db()
+		self.assertIn(
+			"development_status",
+			self.submission_info.modification_description or "",
+		)
+
+	def test_not_found_for_unknown_uid(self):
+		response = self.client.patch(
+			f"/api/data/software/{uuid.uuid4()}/",
+			data={"developmentStatus": "Active"},
+			format="json",
+			HTTP_AUTHORIZATION=self.auth,
+		)
+		self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+	def test_non_visible_software_returns_404(self):
+		hidden = Software.objects.create(software_name="Hidden")
+
+		response = self.client.patch(
+			f"/api/data/software/{hidden.id}/",
+			data={"developmentStatus": "Active"},
+			format="json",
+			HTTP_AUTHORIZATION=self.auth,
+		)
+
+		self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+	def test_user_view_route_does_not_accept_patch(self):
+		response = self.client.patch(
+			f"/api/view/software/{self.software.id}/",
+			data={"developmentStatus": "Active"},
+			format="json",
+			HTTP_AUTHORIZATION=self.auth,
+		)
+		self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+
+
+@override_settings(HSSI_UPDATE_TOKEN=None)
+class SoftwarePartialUpdateTokenUnsetTests(TestCase):
+	"""With no token configured, PATCH fails closed."""
+
+	@classmethod
+	def setUpTestData(cls):
+		cls.software = Software.objects.create(software_name="Test Software")
+		VerifiedSoftware.create_verified(cls.software)
+
+	def test_unset_token_denies_every_patch(self):
+		client = APIClient()
+		response = client.patch(
+			f"/api/data/software/{self.software.id}/",
+			data={"developmentStatus": "Active"},
+			format="json",
+			HTTP_AUTHORIZATION="Bearer anything",
+		)
+		self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+
+class SoftwareListLookupTests(TestCase):
+	"""GET /api/list/software/ with optional ?code_repository_url= filter."""
+
+	@classmethod
+	def setUpTestData(cls):
+		cls.match = Software.objects.create(
+			software_name="Matching",
+			code_repository_url="https://github.com/example/match",
+		)
+		VerifiedSoftware.create_verified(cls.match)
+
+		cls.other = Software.objects.create(
+			software_name="Other",
+			code_repository_url="https://github.com/example/other",
+		)
+		VerifiedSoftware.create_verified(cls.other)
+
+		cls.hidden = Software.objects.create(
+			software_name="Hidden",
+			code_repository_url="https://github.com/example/match",
+		)
+
+		cls.branch_root = Software.objects.create(
+			software_name="Branch Root",
+			code_repository_url="https://github.com/example/branch",
+		)
+		VerifiedSoftware.create_verified(cls.branch_root)
+
+		cls.branch_path = Software.objects.create(
+			software_name="Branch Path",
+			code_repository_url="https://github.com/example/branch/tree/dev",
+		)
+		VerifiedSoftware.create_verified(cls.branch_path)
+
+		cls.gitlab = Software.objects.create(
+			software_name="GitLab Nested",
+			code_repository_url="https://gitlab.com/group/subgroup/project",
+		)
+		VerifiedSoftware.create_verified(cls.gitlab)
+
+	def setUp(self):
+		self.client = APIClient()
+
+	def _lookup_names(self, url: str) -> list[str]:
+		response = self.client.get(
+			"/api/list/software/",
+			{"code_repository_url": url},
+		)
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		return [entry["name"] for entry in response.data["data"]]
+
+	def test_exact_lookup_returns_matching_software(self):
+		names = self._lookup_names("https://github.com/example/match")
+		self.assertEqual(names, ["Matching"])
+
+	def test_lookup_is_case_insensitive(self):
+		names = self._lookup_names("HTTPS://GitHub.com/example/MATCH")
+		self.assertEqual(names, ["Matching"])
+
+	def test_trailing_slash_lookup_matches_root_url(self):
+		names = self._lookup_names("https://github.com/example/match/")
+		self.assertEqual(names, ["Matching"])
+
+	def test_git_suffix_lookup_matches_root_url(self):
+		names = self._lookup_names("https://github.com/example/match.git")
+		self.assertEqual(names, ["Matching"])
+
+	def test_github_branch_url_lookup_returns_all_normalized_matches(self):
+		names = self._lookup_names("https://github.com/example/branch/tree/main")
+		self.assertEqual(names, ["Branch Path", "Branch Root"])
+
+	def test_gitlab_tree_url_lookup_matches_nested_project(self):
+		names = self._lookup_names(
+			"https://gitlab.com/group/subgroup/project/-/tree/main"
+		)
+		self.assertEqual(names, ["GitLab Nested"])
+
+	def test_unknown_lookup_returns_empty(self):
+		names = self._lookup_names("https://github.com/example/nothing")
+		self.assertEqual(names, [])
+
+	def test_no_filter_returns_visible_software_only(self):
+		response = self.client.get("/api/list/software/")
+
+		self.assertEqual(response.status_code, status.HTTP_200_OK)
+		names = [entry["name"] for entry in response.data["data"]]
+		self.assertIn("Matching", names)
+		self.assertIn("Other", names)
+		self.assertNotIn("Hidden", names)

--- a/django/website/views/api/software_api.py
+++ b/django/website/views/api/software_api.py
@@ -13,36 +13,68 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.permissions import AllowAny
 from rest_framework import serializers
+from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.generics import GenericAPIView
 
-from ...models import Software, VerifiedSoftware, SoftwareEditQueue, SubmissionInfo
+from ...models import Software, SoftwareEditQueue, SubmissionInfo
 from ...models.serializers.software import SoftwareSerializer
 from ...models.serializers.submission import SubmissionSerializer
 from ...models.serializers.util import SerialView
 from ..edit_submission import email_existing_edit_link
+from .update_api import (
+	HasUpdateToken,
+	filter_by_code_repository_url,
+	get_visible_software,
+	visible_software_queryset,
+	update_software_from_payload,
+)
 
 
 class HSSIGenericAPIView(GenericAPIView):
 	def get_serializer(self, *args, **kwargs) -> serializers.Serializer:
 		return super().get_serializer(*args, **kwargs)
 
+@method_decorator(csrf_exempt, name="dispatch")
 class SoftwareDetailAPI(HSSIGenericAPIView):
-	"""Return a single visible Software record, with optional flat expansion."""
+	"""Return or partially update a single visible Software record."""
 
 	serializer_class = SoftwareSerializer
 	default_view: SerialView = SerialView.STANDARD
+	authentication_classes = []
+
+	def get_permissions(self):
+		if self.request.method == "PATCH":
+			return [HasUpdateToken()]
+		return [AllowAny()]
 
 	def get(self, request: HttpRequest, uid: str) -> Response:
-		visible_ids = VerifiedSoftware.objects.values_list("id", flat=True)
-		software = Software.objects.filter(pk=uid, pk__in=visible_ids).first()
+		software = get_visible_software(uid)
 		if software is None:
 			return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
 		serializer: SoftwareSerializer = self.get_serializer(software)
 		serializer.default_view = self.default_view
 		return Response(serializer.data)
 
+	def patch(self, request: HttpRequest, uid: str) -> Response:
+		software = get_visible_software(uid)
+		if software is None:
+			return Response({"detail": "Not found."}, status=status.HTTP_404_NOT_FOUND)
+
+		fields_updated = update_software_from_payload(software, request.data)
+		return Response({
+			"status": "ok",
+			"softwareId": str(software.id),
+			"fieldsUpdated": fields_updated,
+		})
+
 class SoftwareViewAPI(SoftwareDetailAPI):
 	default_view: SerialView = SerialView.USER
+
+	def get_permissions(self):
+		return [AllowAny()]
+
+	def patch(self, request: HttpRequest, uid: str) -> Response:
+		raise MethodNotAllowed("PATCH")
 
 class SoftwareListAPI(APIView):
 	"""Return a list of visible Software IDs with their names."""
@@ -51,13 +83,13 @@ class SoftwareListAPI(APIView):
 	permission_classes = [AllowAny]
 
 	def get(self, request: HttpRequest) -> Response:
-		visible_ids = VerifiedSoftware.objects.values_list("id", flat=True)
-		entries = (
-			Software.objects
-			.filter(pk__in=visible_ids)
-			.values("id", "software_name")
-			.order_by("software_name")
-		)
+		queryset = visible_software_queryset()
+
+		code_repository_url = request.query_params.get("code_repository_url")
+		if code_repository_url:
+			queryset = filter_by_code_repository_url(queryset, code_repository_url)
+
+		entries = queryset.values("id", "software_name").order_by("software_name")
 		data = [{"id": str(item["id"]), "name": item["software_name"]} for item in entries]
 		return Response({"data": data})
 

--- a/django/website/views/api/update_api.py
+++ b/django/website/views/api/update_api.py
@@ -1,0 +1,632 @@
+"""Isolated helpers for authenticated Software metadata updates."""
+
+from __future__ import annotations
+
+import secrets
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+from django.conf import settings
+from django.core.exceptions import ValidationError as DjangoValidationError
+from django.core.validators import URLValidator
+from django.db import transaction
+from django.db.models import QuerySet
+from django.utils.dateparse import parse_date
+from rest_framework import serializers
+from rest_framework.permissions import BasePermission
+
+from hssi.camel_case_renderer import decamelize_data
+
+from ...models import (
+	Award,
+	ControlledGraphList,
+	ControlledList,
+	CpuArchitecture,
+	DataInput,
+	FileFormat,
+	FunctionCategory,
+	InstrObsType,
+	InstrumentObservatory,
+	Keyword,
+	License,
+	OperatingSystem,
+	Organization,
+	Person,
+	Phenomena,
+	ProgrammingLanguage,
+	Region,
+	RelatedItem,
+	RelatedItemType,
+	RepoStatus,
+	Software,
+	SoftwareVersion,
+	VerifiedSoftware,
+)
+
+
+USER_ALLOWED_FIELDS: frozenset[str] = frozenset({
+	"submitter",
+	"software_name",
+	"code_repository_url",
+	"description",
+	"concise_description",
+	"documentation",
+	"persistent_identifier",
+	"publication_date",
+	"logo",
+	"publisher",
+	"license",
+	"development_status",
+	"reference_publication",
+	"authors",
+	"programming_language",
+	"input_formats",
+	"output_formats",
+	"operating_system",
+	"cpu_architecture",
+	"software_functionality",
+	"related_region",
+	"related_phenomena",
+	"data_sources",
+	"keywords",
+	"related_instruments",
+	"related_observatories",
+	"related_publications",
+	"related_datasets",
+	"related_software",
+	"interoperable_software",
+	"funder",
+	"award",
+	"version",
+})
+
+USER_LIST_FIELDS: tuple[str, ...] = (
+	"authors",
+	"programming_language",
+	"input_formats",
+	"output_formats",
+	"operating_system",
+	"cpu_architecture",
+	"software_functionality",
+	"related_region",
+	"related_phenomena",
+	"data_sources",
+	"keywords",
+	"related_instruments",
+	"related_observatories",
+	"related_publications",
+	"related_datasets",
+	"related_software",
+	"interoperable_software",
+	"funder",
+	"award",
+)
+
+
+class HasUpdateToken(BasePermission):
+	"""Bearer-token permission for HSSI update endpoints."""
+
+	message = "Missing or invalid update token."
+
+	def has_permission(self, request, view):
+		expected = getattr(settings, "HSSI_UPDATE_TOKEN", None)
+		if not expected:
+			return False
+		auth_header = request.META.get("HTTP_AUTHORIZATION", "")
+		prefix = "Bearer "
+		if not auth_header.startswith(prefix):
+			return False
+		provided = auth_header[len(prefix):]
+		return secrets.compare_digest(provided, expected)
+
+
+def visible_software_queryset() -> QuerySet[Software]:
+	"""Return visible Software rows only."""
+	visible_ids = VerifiedSoftware.objects.values_list("id", flat=True)
+	return Software.objects.filter(pk__in=visible_ids)
+
+
+def get_visible_software(uid: str) -> Software | None:
+	"""Look up a Software row only if it is visible."""
+	return visible_software_queryset().filter(pk=uid).first()
+
+
+def filter_by_code_repository_url(
+	queryset: QuerySet[Software],
+	code_repository_url: str,
+) -> QuerySet[Software]:
+	"""Filter visible Software by repository URL with lightweight normalization."""
+	url = code_repository_url.strip()
+	if not url:
+		return queryset
+
+	exact_matches = queryset.filter(code_repository_url__iexact=url)
+	if exact_matches.exists():
+		return exact_matches
+
+	target = canonical_code_repository_url(url)
+	if target is None:
+		return queryset.none()
+
+	match_ids = []
+	for software in queryset.exclude(
+		code_repository_url__isnull=True,
+	).exclude(
+		code_repository_url="",
+	).only("id", "code_repository_url"):
+		candidate = canonical_code_repository_url(software.code_repository_url)
+		if candidate is not None and candidate.casefold() == target.casefold():
+			match_ids.append(software.id)
+
+	return queryset.filter(id__in=match_ids)
+
+
+def canonical_code_repository_url(url: str | None) -> str | None:
+	"""Normalize URL variants enough for target discovery, not storage."""
+	if url is None:
+		return None
+	raw = url.strip()
+	if not raw:
+		return None
+
+	parsed = urlparse(raw)
+	if not parsed.netloc:
+		return raw.rstrip("/").removesuffix(".git")
+
+	scheme = parsed.scheme.lower()
+	netloc = parsed.netloc.lower()
+	path_parts = [part for part in parsed.path.split("/") if part]
+
+	if netloc == "github.com" and len(path_parts) >= 2:
+		path_parts = path_parts[:2]
+	elif netloc == "gitlab.com" and "/-/" in parsed.path:
+		dash_index = path_parts.index("-")
+		path_parts = path_parts[:dash_index]
+
+	if path_parts:
+		path_parts[-1] = path_parts[-1].removesuffix(".git")
+
+	path = "/" + "/".join(path_parts) if path_parts else ""
+	return urlunparse((scheme, netloc, path.rstrip("/"), "", "", ""))
+
+
+def update_software_from_payload(
+	software: Software,
+	payload: dict[str, Any],
+) -> list[str]:
+	"""Validate and apply a partial user-view payload to a Software row."""
+	data = decamelize_data(payload)
+	if not isinstance(data, dict):
+		raise serializers.ValidationError({"detail": "Root JSON value must be an object."})
+	if not data:
+		raise serializers.ValidationError({"detail": "At least one field is required."})
+
+	validate_patch_data(data)
+
+	with transaction.atomic():
+		changed = apply_user_update_fields(software, data)
+		touch_submission_info(software, changed)
+	return sorted(changed)
+
+
+def validate_patch_data(data: dict[str, Any]) -> None:
+	"""Validate field names and top-level shapes before applying updates."""
+	unknown = set(data.keys()) - USER_ALLOWED_FIELDS
+	if unknown:
+		raise serializers.ValidationError({
+			key: "Unknown field." for key in sorted(unknown)
+		})
+
+	if "submitter" in data:
+		raise serializers.ValidationError({
+			"submitter": "Updating submitter is not supported via PATCH."
+		})
+
+	for field in USER_LIST_FIELDS:
+		if field in data and data[field] is not None and not isinstance(data[field], list):
+			raise serializers.ValidationError({field: "Expected an array."})
+
+	if "publisher" in data and data["publisher"] is not None and not isinstance(data["publisher"], dict):
+		raise serializers.ValidationError({"publisher": "Expected an object."})
+	if "version" in data and data["version"] is not None and not isinstance(data["version"], dict):
+		raise serializers.ValidationError({"version": "Expected an object."})
+
+
+def apply_user_update_fields(software: Software, data: dict[str, Any]) -> list[str]:
+	"""Apply only fields present in the patch payload."""
+	changed: list[str] = []
+
+	if "software_name" in data:
+		software.software_name = _normalize_term(data["software_name"], "software_name")
+		changed.append("software_name")
+	if "code_repository_url" in data:
+		software.code_repository_url = _validate_optional_url(
+			data["code_repository_url"], "code_repository_url"
+		)
+		changed.append("code_repository_url")
+	if "description" in data:
+		software.description = _optional_string(data["description"], "description")
+		changed.append("description")
+	if "concise_description" in data:
+		concise = _optional_string(data["concise_description"], "concise_description")
+		if concise is not None and len(concise) > 200:
+			raise serializers.ValidationError({
+				"concise_description": "Must be 200 characters or fewer."
+			})
+		software.concise_description = concise
+		changed.append("concise_description")
+	if "documentation" in data:
+		software.documentation = _validate_optional_url(data["documentation"], "documentation")
+		changed.append("documentation")
+	if "persistent_identifier" in data:
+		software.persistent_identifier = _validate_optional_url(
+			data["persistent_identifier"], "persistent_identifier"
+		)
+		changed.append("persistent_identifier")
+	if "publication_date" in data:
+		software.publication_date = _validate_optional_date(
+			data["publication_date"], "publication_date"
+		)
+		changed.append("publication_date")
+	if "logo" in data:
+		software.logo = _validate_optional_url(data["logo"], "logo")
+		changed.append("logo")
+
+	if "publisher" in data:
+		software.publisher = None if data["publisher"] is None else _get_or_create_org(data["publisher"])
+		changed.append("publisher")
+	if "license" in data:
+		software.license = _get_license(data["license"])
+		changed.append("license")
+	if "development_status" in data:
+		value = data["development_status"]
+		software.development_status = (
+			None if value in (None, "") else _get_controlled_item(RepoStatus, value)
+		)
+		changed.append("development_status")
+	if "reference_publication" in data:
+		value = data["reference_publication"]
+		software.reference_publication = (
+			None if value in (None, "") else _get_or_create_related(value, RelatedItemType.PUBLICATION)
+		)
+		changed.append("reference_publication")
+
+	software.save()
+
+	_set_people(software, data, changed)
+	_set_controlled_lists(software, data, changed)
+	_set_related_objects(software, data, changed)
+	_set_version(software, data, changed)
+
+	software.save()
+	return changed
+
+
+def touch_submission_info(software: Software, changed: list[str]) -> None:
+	"""Record the partial update on the most recent SubmissionInfo."""
+	submission_info = software.submission_info.order_by("-date_modified").first()
+	if submission_info is None:
+		return
+	submission_info.modification_description = (
+		f"Partial update via API: {', '.join(sorted(changed))}"
+	)
+	submission_info.save()
+
+
+def _set_people(software: Software, data: dict[str, Any], changed: list[str]) -> None:
+	if "authors" not in data:
+		return
+	authors_data = data["authors"] or []
+	authors = [_get_or_create_person(item) for item in authors_data]
+	for author, author_data in zip(authors, authors_data, strict=False):
+		affiliations = author_data.get("affiliation") or []
+		if not isinstance(affiliations, list):
+			raise serializers.ValidationError({"affiliation": "Expected an array."})
+		for org_data in affiliations:
+			if not isinstance(org_data, dict):
+				raise serializers.ValidationError({"affiliation": "Expected an object."})
+			author.affiliation.add(_get_or_create_org(org_data))
+	software.authors.set(authors)
+	changed.append("authors")
+
+
+def _set_controlled_lists(
+	software: Software,
+	data: dict[str, Any],
+	changed: list[str],
+) -> None:
+	controlled_m2m = {
+		"programming_language": (ProgrammingLanguage, software.programming_language),
+		"input_formats": (FileFormat, software.input_formats),
+		"output_formats": (FileFormat, software.output_formats),
+		"operating_system": (OperatingSystem, software.operating_system),
+		"cpu_architecture": (CpuArchitecture, software.cpu_architecture),
+		"data_sources": (DataInput, software.data_sources),
+	}
+	for field, (model, manager) in controlled_m2m.items():
+		if field in data:
+			manager.set([
+				_get_controlled_item(model, value)
+				for value in (data[field] or [])
+			])
+			changed.append(field)
+
+	graph_m2m = {
+		"software_functionality": (FunctionCategory, software.software_functionality),
+		"related_region": (Region, software.related_region),
+		"related_phenomena": (Phenomena, software.related_phenomena),
+	}
+	for field, (model, manager) in graph_m2m.items():
+		if field in data:
+			manager.set([
+				_get_graph_list_item(model, value)
+				for value in (data[field] or [])
+			])
+			changed.append(field)
+
+	if "keywords" in data:
+		software.keywords.set([
+			_get_or_create_keyword(value)
+			for value in (data["keywords"] or [])
+		])
+		changed.append("keywords")
+
+
+def _set_related_objects(
+	software: Software,
+	data: dict[str, Any],
+	changed: list[str],
+) -> None:
+	if "related_instruments" in data:
+		software.related_instruments.set([
+			_get_or_create_observatory(item, InstrObsType.INSTRUMENT)
+			for item in (data["related_instruments"] or [])
+		])
+		changed.append("related_instruments")
+	if "related_observatories" in data:
+		software.related_observatories.set([
+			_get_or_create_observatory(item, InstrObsType.OBSERVATORY)
+			for item in (data["related_observatories"] or [])
+		])
+		changed.append("related_observatories")
+
+	related_m2m = {
+		"related_publications": (software.related_publications, RelatedItemType.PUBLICATION),
+		"related_datasets": (software.related_datasets, RelatedItemType.DATASET),
+		"related_software": (software.related_software, RelatedItemType.SOFTWARE),
+		"interoperable_software": (software.interoperable_software, RelatedItemType.SOFTWARE),
+	}
+	for field, (manager, item_type) in related_m2m.items():
+		if field in data:
+			manager.set([
+				_get_or_create_related(value, item_type)
+				for value in (data[field] or [])
+			])
+			changed.append(field)
+
+	if "funder" in data:
+		software.funder.set([
+			_get_or_create_org(item)
+			for item in (data["funder"] or [])
+		])
+		changed.append("funder")
+	if "award" in data:
+		software.award.set([
+			_get_or_create_award(item)
+			for item in (data["award"] or [])
+		])
+		changed.append("award")
+
+
+def _set_version(
+	software: Software,
+	data: dict[str, Any],
+	changed: list[str],
+) -> None:
+	if "version" not in data:
+		return
+	version = data["version"]
+	if version is None:
+		software.version.clear()
+	else:
+		version_obj = SoftwareVersion.objects.create(
+			number=_normalize_term(version.get("number"), "version.number"),
+			release_date=_validate_optional_date(version.get("release_date"), "version.release_date"),
+			description=_optional_string(version.get("description"), "version.description"),
+			version_pid=_validate_optional_url(version.get("version_pid"), "version.version_pid"),
+		)
+		software.version.set([version_obj])
+	changed.append("version")
+
+
+def _optional_string(value: Any, field_name: str) -> str | None:
+	if value is None:
+		return None
+	if not isinstance(value, str):
+		raise serializers.ValidationError({field_name: "Expected a string."})
+	stripped = value.strip()
+	return stripped or None
+
+
+def _normalize_term(value: Any, field_name: str) -> str:
+	value = _optional_string(value, field_name)
+	if value is None:
+		raise serializers.ValidationError({field_name: "Value cannot be empty."})
+	return value
+
+
+def _validate_optional_url(value: Any, field_name: str) -> str | None:
+	value = _optional_string(value, field_name)
+	if value is None:
+		return None
+	validator = URLValidator()
+	try:
+		validator(value)
+	except DjangoValidationError:
+		raise serializers.ValidationError({field_name: f"Invalid URL: '{value}'"})
+	return value
+
+
+def _validate_optional_date(value: Any, field_name: str):
+	value = _optional_string(value, field_name)
+	if value is None:
+		return None
+	parsed = parse_date(value)
+	if parsed is None:
+		raise serializers.ValidationError({field_name: f"Invalid date: '{value}'"})
+	return parsed
+
+
+def _get_controlled_item(
+	model: type[ControlledList],
+	value: Any,
+) -> ControlledList:
+	normalized = _normalize_term(value, model.__name__)
+	obj = model.objects.filter(name__iexact=normalized).first()
+	if not obj:
+		raise serializers.ValidationError({model.__name__: f"Unknown value '{value}'."})
+	return obj
+
+
+def _get_graph_list_item(
+	model: type[ControlledGraphList],
+	value: Any,
+) -> ControlledGraphList:
+	normalized = _normalize_term(value, model.__name__)
+	if ":" not in normalized:
+		obj = model.objects.filter(name__iexact=normalized).first()
+		if not obj:
+			raise serializers.ValidationError({model.__name__: f"Unknown value '{value}'."})
+		return obj
+
+	parts = [part.strip() for part in normalized.split(":")]
+	parent = model.objects.filter(name__iexact=parts[0], parent_nodes__isnull=True).first()
+	if not parent:
+		raise serializers.ValidationError({model.__name__: f"Unknown value '{value}'."})
+	for part in parts[1:]:
+		child = model.objects.filter(name__iexact=part, parent_nodes=parent).first()
+		if not child:
+			raise serializers.ValidationError({model.__name__: f"Unknown value '{value}'."})
+		parent = child
+	return parent
+
+
+def _get_or_create_keyword(value: Any) -> Keyword:
+	normalized = _normalize_term(value, Keyword.__name__)
+	obj = Keyword.objects.filter(name__iexact=normalized).first()
+	if obj:
+		return obj
+	return Keyword.objects.create(name=normalized)
+
+
+def _get_or_create_person(data: Any) -> Person:
+	if not isinstance(data, dict):
+		raise serializers.ValidationError({"person": "Expected an object."})
+	given_name = _normalize_term(data.get("given_name"), "given_name")
+	family_name = _normalize_term(data.get("family_name"), "family_name")
+	identifier = _validate_optional_url(data.get("identifier"), "identifier")
+	if identifier:
+		person = Person.objects.filter(identifier=identifier).first()
+		if person:
+			if not person.given_name:
+				person.given_name = given_name
+			if not person.family_name:
+				person.family_name = family_name
+			person.save()
+			return person
+		return Person.objects.create(
+			given_name=given_name,
+			family_name=family_name,
+			identifier=identifier,
+		)
+
+	person = Person.objects.filter(
+		given_name=given_name,
+		family_name=family_name,
+	).first()
+	if person:
+		return person
+	return Person.objects.create(given_name=given_name, family_name=family_name)
+
+
+def _get_or_create_org(data: Any) -> Organization:
+	if not isinstance(data, dict):
+		raise serializers.ValidationError({"organization": "Expected an object."})
+	name = _normalize_term(data.get("name"), "name")
+	identifier = _validate_optional_url(data.get("identifier"), "identifier")
+	if identifier:
+		org = Organization.objects.filter(identifier=identifier).first()
+		if org:
+			if not org.name:
+				org.name = name
+				org.save()
+			return org
+		return Organization.objects.create(name=name, identifier=identifier)
+
+	org = Organization.objects.filter(name__iexact=name).first()
+	if org:
+		return org
+	return Organization.objects.create(name=name)
+
+
+def _get_or_create_observatory(
+	data: Any,
+	instr_type: InstrObsType,
+) -> InstrumentObservatory:
+	if not isinstance(data, dict):
+		raise serializers.ValidationError({"instrument_observatory": "Expected an object."})
+	name = _normalize_term(data.get("name"), "name")
+	identifier = _validate_optional_url(data.get("identifier"), "identifier")
+	if identifier:
+		entry = InstrumentObservatory.objects.filter(identifier=identifier).first()
+		if entry:
+			return entry
+		return InstrumentObservatory.objects.create(
+			name=name,
+			identifier=identifier,
+			type=instr_type,
+		)
+	entry = InstrumentObservatory.objects.filter(name__iexact=name, type=instr_type).first()
+	if entry:
+		return entry
+	return InstrumentObservatory.objects.create(name=name, type=instr_type)
+
+
+def _get_or_create_award(data: Any) -> Award:
+	if not isinstance(data, dict):
+		raise serializers.ValidationError({"award": "Expected an object."})
+	name = _normalize_term(data.get("name"), "name")
+	identifier = _optional_string(data.get("identifier"), "identifier")
+	if identifier:
+		award = Award.objects.filter(identifier=identifier).first()
+		if award:
+			return award
+		return Award.objects.create(name=name, identifier=identifier)
+	award = Award.objects.filter(name__iexact=name).first()
+	if award:
+		return award
+	return Award.objects.create(name=name)
+
+
+def _get_or_create_related(value: Any, item_type: RelatedItemType) -> RelatedItem:
+	identifier = _validate_optional_url(value, "identifier")
+	if identifier is None:
+		raise serializers.ValidationError({"identifier": "Value cannot be empty."})
+	item = RelatedItem.objects.filter(identifier=identifier).first()
+	if item:
+		return item
+	return RelatedItem.objects.create(
+		name=identifier,
+		identifier=identifier,
+		type=item_type,
+	)
+
+
+def _get_license(value: Any) -> License | None:
+	if value in (None, ""):
+		return None
+	normalized = _normalize_term(value, "license")
+	license_obj = License.objects.filter(name__iexact=normalized).first()
+	if not license_obj:
+		raise serializers.ValidationError({"license": f"Unknown license '{value}'."})
+	return license_obj

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,7 @@ services:
             - SUPERUSER_PWD=$SUPERUSER_PWD
             - GMAIL_EMAIL=${GMAIL_EMAIL}
             - GMAIL_APP_PASSWORD=${GMAIL_APP_PASSWORD}
+            - HSSI_UPDATE_TOKEN=${HSSI_UPDATE_TOKEN}
             - PROJECT_NAME=hssi
             - APP_NAME=website
             - GUNICORN_WORKERS=4


### PR DESCRIPTION
## Updater API Comparison

This PR is **option 2 of 3: v3**, the isolated PATCH approach.

These three draft PRs implement the same updater-agent capability with different architecture trade-offs:

| Option | PR | Branch | Public API | Implementation shape | Main trade-off |
| --- | --- | --- | --- | --- | --- |
| v2 | #28 | `feature/update-api-v2` | `PATCH /api/data/software/<uid>/` plus `GET /api/list/software/?repo_url=...` | Reuses and refactors the existing submission serializer path for both create and update | Most shared logic, but touches the most existing submitter/serializer code |
| v3 | #29 | `feature/update-api-v3` | `PATCH /api/data/software/<uid>/` plus `GET /api/list/software/?code_repository_url=...` | Keeps PATCH as the public API, but moves update behavior into a separate update module | REST-style endpoint with much less disruption to existing submitter code |
| v4 | #30 | `feature/update-api-v4` | `POST /api/update` plus `GET /api/update/lookup?code_repository_url=...` | Fully separate command-style update API and lookup API | Maximum isolation from existing views/serializers, but less REST-idiomatic than PATCH |

Reviewer note: these PRs are alternatives, not stacked changes. They are meant to be compared side by side before choosing one approach.

## Summary

Adds a bearer-token-gated partial update endpoint for software metadata while keeping update logic isolated from the existing submission serializer path. PATCH lands on the existing detail URL because it is the REST-idiomatic spelling for partial mutation of a specific software record, but the mutation implementation lives in a new update-focused module instead of refactoring `SubmissionSerializer` or `HssiSerializer`.

This is the v3 approach: keep the clean `PATCH /api/data/software/<uid>/` API shape from v2, but preserve the separated implementation style from `feature/update-api` so existing submitter code remains mostly untouched.

## Endpoints

- `PATCH /api/data/software/<uid>/` — bearer-token partial update of a visible software record. Only keys present in the body are applied; missing keys leave existing values untouched; explicit null/empty values clear nullable fields; empty lists clear M2M fields.
- `GET /api/list/software/?code_repository_url=<url>` — optional repository URL lookup for resolving a repo URL to visible software UUIDs before issuing PATCH. The parameter uses the canonical model/API field name rather than the shorthand `repo_url`.

## Architecture

**Auth.** A new `HasUpdateToken` DRF permission reads `settings.HSSI_UPDATE_TOKEN` and compares the bearer token with `secrets.compare_digest`. It fails closed when the setting is unset or empty. `docker-compose.yml` passes the env var through to the Django container.

**Isolation.** New update logic lives in `website/views/api/update_api.py`. It owns token permission, visible-software helpers, field validation, field application, audit-touch behavior, and repository URL normalization. `SubmissionSerializer` and `HssiSerializer` are intentionally unchanged.

**Views.** `SoftwareDetailAPI` grows a small `patch()` handler that checks visibility and delegates mutation to the isolated update module. `GET` behavior is unchanged except for sharing the visible-software lookup helper. `SoftwareViewAPI` explicitly rejects PATCH so only `/api/data/software/<uid>/` is mutable.

**Lookup.** `SoftwareListAPI` now supports `?code_repository_url=`. It first tries an exact case-insensitive database match, then a lightweight normalized match that handles trailing slash, terminal `.git`, GitHub branch/blob paths, and GitLab `/-/tree` or `/-/blob` paths. Multiple matches are returned rather than guessed.

**Tests.** Regression coverage in `django/website/test_update_api.py` covers PATCH success and failure cases, token handling, visible-record gating, audit side effects, route scoping, and repository URL lookup normalization.

## Test plan

- [x] `python -m py_compile django/website/views/api/update_api.py django/website/views/api/software_api.py django/website/test_update_api.py`
- [x] `docker exec HSSI python /django/manage.py test website.test_update_api` — 23/23 pass
- [x] `docker exec HSSI python /django/manage.py test website` — 25/25 pass
- [ ] Reviewer: set `HSSI_UPDATE_TOKEN` in your local `.env` and smoke-test a real PATCH against localhost before merging
- [ ] Reviewer: confirm `HSSI_UPDATE_TOKEN` is set on the production host environment, or deliberately left unset to disable the endpoint before deploying
