### PR TITLE
Group functionality badges on software detail pages

### DIFF
--- a/django/website/models/software.py
+++ b/django/website/models/software.py
@@ -210,6 +210,28 @@ class Software(HssiModel):
 				break
 		return subfields
 
+	def get_ordered_software_functionality(self) -> list[FunctionCategory]:
+		"""Return functionality tags with parent/child groups kept together."""
+		categories = list(
+			self.software_functionality.prefetch_related("parent_nodes").all()
+		)
+		parent_map = {
+			category.id: list(category.parent_nodes.all())
+			for category in categories
+		}
+		groups: dict[uuid.UUID, list[FunctionCategory]] = {}
+		for category in categories:
+			parents = parent_map[category.id]
+			group_id = parents[0].id if parents else category.id
+			groups.setdefault(group_id, []).append(category)
+
+		ordered: list[FunctionCategory] = []
+		for group in groups.values():
+			ordered.extend(
+				sorted(group, key=lambda category: bool(parent_map[category.id]))
+			)
+		return ordered
+
 	def __str__(self): return self.software_name
 
 	def get_absolute_url(self):

--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -203,11 +203,11 @@
         {% endif %}
 
         <!-- Functionality Section -->
-        {% if software.software_functionality.all %}
+        {% if functionality_tags %}
         <details class="software-section" open>
             <summary class="section-title">Functionality</summary>
             <div class="functionality-tags">
-                {% for func in software.software_functionality.all %}
+                {% for func in functionality_tags %}
                 <a href="{{ func.get_homepage_filter_url }}"
                    class="tag functionality-tag"
                    title="View software filtered by {{ func.name }}"

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -1,8 +1,8 @@
 import uuid
 
-from django.test import SimpleTestCase
+from django.test import SimpleTestCase, TestCase
 
-from .models import DataInput, FunctionCategory, ProgrammingLanguage, Region
+from .models import DataInput, FunctionCategory, ProgrammingLanguage, Region, Software
 from .util import build_software_filter_query, shorten_software_filter_value
 
 FILTER_CASES = [
@@ -30,3 +30,56 @@ class SoftwareFilterEncodingTests(SimpleTestCase):
 					obj.get_homepage_filter_url(),
 					f"/?{build_software_filter_query(field, obj.id)}",
 				)
+
+
+class SoftwareFunctionalityOrderingTests(TestCase):
+	def test_functionality_groups_stay_together_without_inserting_parents(self):
+		names = [
+			"Data Visualization",
+			"Line Plots",
+			"Spectrogram",
+			"Models and Simulations",
+			"Data Processing and Analysis",
+			"Analysis",
+		]
+		categories = {
+			name: FunctionCategory.objects.create(name=name)
+			for name in names
+		}
+		categories["Data Visualization"].children.add(
+			categories["Line Plots"], categories["Spectrogram"]
+		)
+		categories["Data Processing and Analysis"].children.add(categories["Analysis"])
+
+		def ordered_names(selected: list[str]) -> list[str]:
+			software = Software.objects.create(software_name="Test Software")
+			software.software_functionality.set([categories[name] for name in selected])
+			return [
+				func.name
+				for func in software.get_ordered_software_functionality()
+			]
+
+		self.assertEqual(
+			ordered_names(
+				[
+					"Data Visualization",
+					"Models and Simulations",
+					"Data Processing and Analysis",
+					"Analysis",
+					"Line Plots",
+					"Spectrogram",
+				]
+			),
+			[
+				"Data Visualization",
+				"Line Plots",
+				"Spectrogram",
+				"Models and Simulations",
+				"Data Processing and Analysis",
+				"Analysis",
+			],
+		)
+		self.assertEqual(
+			ordered_names(["Line Plots", "Analysis"]),
+			["Line Plots", "Analysis"],
+		)

--- a/django/website/views/software_detail.py
+++ b/django/website/views/software_detail.py
@@ -23,15 +23,18 @@ class SoftwareDetailView(generic.DetailView):
         return Software.objects.filter(pk__in=visible_ids)
 
     def get_context_data(self, **kwargs: Any) -> dict[str, Any]:
-        """Add the latest SoftwareVersion to the template context."""
+        """Add display data to the software detail template context."""
         context = super().get_context_data(**kwargs)
         software: Optional[Software] = context.get('software')
         latest_version: Optional[SoftwareVersion] = None
+        functionality_tags = []
         if software is not None:
             latest_version = (
                 software.version.all()
                 .order_by('-release_date', '-number')
                 .first()
             )
+            functionality_tags = software.get_ordered_software_functionality()
         context['latest_version'] = latest_version
+        context['functionality_tags'] = functionality_tags
         return context


### PR DESCRIPTION
This PR fixes a bug where color-coded software functionality badges on landing pages weren't grouped together, causing the ordering to be random and look weird.

E.g. before:
<img width="1243" height="340" alt="Screenshot 2026-04-15 at 11 09 02 AM" src="https://github.com/user-attachments/assets/502fc657-48d3-448c-a1dc-9dcaceb1e1b2" />

After:
<img width="1243" height="337" alt="Screenshot 2026-04-15 at 11 09 21 AM" src="https://github.com/user-attachments/assets/debb6e01-d006-4b13-89b2-36427bd6b651" />

## Summary
- Adds `Software.get_ordered_software_functionality()` which groups functionality tags by parent, keeping each parent adjacent to its children.
- Threads the ordered list through `SoftwareDetailView` as `functionality_tags` and updates `software_detail.html` to render from it.
- Expands `website/tests.py` with coverage for the new grouping behavior.

## Test plan
- [x] `python manage.py test website` passes
- [x] Visit a software detail page with parent/child functionality tags and confirm related badges render next to each other
- [x] Visit a software detail page with no functionality tags and confirm the Functionality section is hidden