### PR TITLE
Fix JSON-LD tests for slug redirects

### DIFF
--- a/django/website/models/software.py
+++ b/django/website/models/software.py
@@ -258,6 +258,9 @@ class Software(HssiModel):
 
 	def get_absolute_url(self):
 		from django.urls import reverse
+		verified = VerifiedSoftware.objects.filter(pk=self.pk).only("slug").first()
+		if verified and verified.slug:
+			return reverse('website:software_detail', kwargs={'slug': verified.slug})
 		return reverse('website:software_detail', kwargs={'pk': str(self.pk)})
 
 	"""if the software is visible on the website"""

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -100,7 +100,7 @@ class SoftwareFunctionalityOrderingTests(TestCase):
 class SoftwareDetailJsonLdTests(TestCase):
 	def _publish_software(self, **kwargs) -> Software:
 		software = Software.objects.create(**kwargs)
-		VerifiedSoftware.objects.create(id=software.id, slug=str(software.id))
+		VerifiedSoftware.create_verified(software)
 		return software
 
 	def _jsonld_scripts(self, html: str) -> list[str]:
@@ -124,7 +124,12 @@ class SoftwareDetailJsonLdTests(TestCase):
 		)
 		software.version.add(version)
 
-		url = reverse("website:software_detail", kwargs={"pk": software.pk})
+		uuid_url = reverse("website:software_detail", kwargs={"pk": software.pk})
+		url = software.get_absolute_url()
+		redirect_response = self.client.get(uuid_url)
+		self.assertEqual(redirect_response.status_code, 301)
+		self.assertEqual(redirect_response["Location"], url)
+
 		response = self.client.get(url)
 
 		self.assertEqual(response.status_code, 200)
@@ -166,7 +171,7 @@ class SoftwareDetailJsonLdTests(TestCase):
 			description=description,
 		)
 
-		url = reverse("website:software_detail", kwargs={"pk": software.pk})
+		url = software.get_absolute_url()
 		response = self.client.get(url)
 
 		self.assertEqual(response.status_code, 200)

--- a/django/website/views/software_detail.py
+++ b/django/website/views/software_detail.py
@@ -5,6 +5,7 @@ from typing import Any, Optional
 
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db.models import QuerySet
+from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.views import generic
 from django.http import Http404, HttpResponsePermanentRedirect
@@ -28,7 +29,9 @@ class SoftwareDetailView(generic.DetailView):
             pk = self.kwargs.get('pk')
             software = VerifiedSoftware.objects.filter(pk=pk).first()
             if software:
-                return HttpResponsePermanentRedirect(f"/software/{software.slug}")
+                return HttpResponsePermanentRedirect(
+                    reverse('website:software_detail', kwargs={'slug': software.slug})
+                )
         return super().get(request, *args, **kwargs)
 
     def get_queryset(self) -> QuerySet[Software]:


### PR DESCRIPTION
## Summary

Commit `78acfb4` (`implement slug redirects from uuid urls`) changed published software UUID landing pages from direct 200 responses into permanent redirects from `/software/<uuid>/` to `/software/<slug>/`. The JSON-LD landing-page tests were added before that redirect behavior and still requested the UUID URL while asserting a direct 200 response, so they started failing with 301.

This PR keeps the slug redirect behavior and updates the surrounding canonical URL handling so the landing page, embedded JSON-LD, and tests agree on the slug URL as the canonical software page.

## Why each change is needed

- `django/website/tests.py`: updates the JSON-LD tests to request the canonical slug URL for page rendering, while adding an explicit assertion that the UUID URL permanently redirects to that slug URL. This fixes the stale test expectation without losing coverage for the new redirect behavior.

- `django/website/models/software.py`: updates `Software.get_absolute_url()` to return the verified slug URL when one exists, falling back to the UUID URL only for software without a verified slug. This matters beyond the tests because the JSON-LD serializer uses `get_absolute_url()` for `subjectOf.contentUrl`; without this change, a slug landing page would embed JSON-LD that points back to the now-redirecting UUID URL.

- `django/website/views/software_detail.py`: changes the UUID redirect target to use `reverse("website:software_detail", kwargs={"slug": software.slug})` instead of a hand-built `/software/{slug}` string. This keeps the redirect aligned with the URLconf and redirects directly to the slash-terminated canonical route instead of depending on URL string duplication.

## Validation

- `docker exec -w /django HSSI python manage.py test website.tests.SoftwareDetailJsonLdTests`
- `docker exec -w /django HSSI python manage.py test website`
