### PR TITLE
Fix function category choice labels

### DIFF
--- a/django/website/models/vocab.py
+++ b/django/website/models/vocab.py
@@ -126,14 +126,9 @@ class FunctionCategory(ControlledGraphList):
 	parent_nodes: models.Manager['FunctionCategory']
 
 	def get_choice(self) -> ModelObjectChoice:
-		choice_name = str(self)
-		if self.parent_nodes:
-			if self.parent_nodes.count() == 1:
-				choice_name = str(self.parent_nodes.first()) + ": " + choice_name
-
 		return ModelObjectChoice(
 			str(self.id), 
-			choice_name,
+			self.get_full_name(),
 			self.get_search_terms(),
 			self.get_tooltip(),
 		)

--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -45,6 +45,24 @@ class SoftwareFilterEncodingTests(SimpleTestCase):
 
 
 class SoftwareFunctionalityOrderingTests(TestCase):
+	def test_functionality_choice_labels_include_parent_once(self):
+		data_visualization = FunctionCategory.objects.create(name="Data Visualization")
+		spectrogram = FunctionCategory.objects.create(name="Spectrogram")
+		mission_related = FunctionCategory.objects.create(name="Mission-related")
+		analysis = FunctionCategory.objects.create(name="Analysis")
+
+		data_visualization.children.add(spectrogram)
+		mission_related.children.add(analysis)
+
+		self.assertEqual(
+			spectrogram.get_choice().name,
+			"Data Visualization: Spectrogram",
+		)
+		self.assertEqual(
+			analysis.get_choice().name,
+			"Mission-related: Analysis",
+		)
+
 	def test_functionality_groups_stay_together_without_inserting_parents(self):
 		names = [
 			"Data Visualization",


### PR DESCRIPTION
## Summary

Fix duplicated parent names in software functionality choices in the Resource Submission form. Child functionality labels now use `FunctionCategory.get_full_name()` directly instead of prepending the parent to `str(self)`, which already resolves to the full path.

## Root Cause

Commit [bd8e360](https://github.com/Heliophysics-Software-Search-Interface/hssi-website/commit/bd8e360616583d7088fb744e0c2205e24f90f67d) (`vocab.py`) changed `FunctionCategory.__str__()` to return `get_full_name()`, but `get_choice()` still built labels by prepending the parent name to `str(self)`. That made choices like `Data Visualization: Data Visualization: Spectrogram` and `Mission-related: Mission-related: Analysis`.

## Changes

- Simplified `FunctionCategory.get_choice()` to return `self.get_full_name()` as the choice label.
- Added a regression test covering child labels under `Data Visualization` and `Mission-related`, ensuring each parent appears exactly once.

## Validation

- `docker exec HSSI python /django/manage.py test website.tests.SoftwareFunctionalityOrderingTests`
- `docker exec HSSI python /django/manage.py test website`
- Verified against the running container that `get_choice()` now returns labels such as `Data Visualization: Spectrogram`, `Data Visualization: Web-Based`, and `Mission-related: Analysis`.
