### PR TITLE
Guard missing version PID in JSON-LD

### DIFF
--- a/django/website/models/serializers/software.py
+++ b/django/website/models/serializers/software.py
@@ -367,7 +367,8 @@ class SoftwareSerializer(HssiSerializer):
 
 		json_id = instance.persistent_identifier
 		if not json_id:
-			if latest_version: json_id = latest_version.version_pid.strip()
+			if latest_version and latest_version.version_pid:
+				json_id = latest_version.version_pid.strip()
 			if not json_id: json_id = instance.code_repository_url
 
 		data: dict[str, Any] = {


### PR DESCRIPTION
## Summary

Adds a minimal guard before calling `.strip()` on `latest_version.version_pid` while building software JSON-LD.

## Problem

Software detail pages generate JSON-LD via `SoftwareSerializer.to_representation_jsonld`. When a software record has no persistent identifier but does have a latest version whose `version_pid` is null, the serializer called `.strip()` on `None`, raising `AttributeError` and returning HTTP 500 for affected detail pages.

Production logs showed this on pages such as `/software/madrigalweb/`, `/software/hwm-93/`, `/software/iri-90/`, and `/software/wmm2015/`.

## Change

The fallback now only strips `version_pid` when it is present. If it is missing or empty, the existing next fallback to `instance.code_repository_url` remains unchanged.

## Validation

Ran `python -m py_compile django/website/models/serializers/software.py`.