### PR TITLE
Add restart policies to Compose services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,7 @@ services:
         build: ./docker
         image: hssi
         container_name: HSSI
+        restart: unless-stopped
         depends_on:
             - website_db
         ports:
@@ -31,6 +32,7 @@ services:
     website_db:
         image: postgres
         container_name: website_db
+        restart: unless-stopped
         environment: 
             - POSTGRES_PASSWORD=$SUPERUSER_PWD
         # To persist db data, uncomment the following volumes statement, and see the outer 


### PR DESCRIPTION
## Summary

Adds `restart: unless-stopped` to both Docker Compose services:

- `hssi`
- `website_db`

## Problem

The production outage investigation showed that an `apt-get upgrade` run through AWS SSM restarted the Docker daemon. Docker came back successfully, but the HSSI and Postgres containers had `restart=no`, so they remained stopped until manually restarted. That left nothing listening behind the AWS load balancer and produced site-wide 502 responses.

## Change

The Compose services now use `restart: unless-stopped`, so they should come back automatically after Docker daemon restarts, host restarts, or package-maintenance-driven Docker restarts unless an operator explicitly stops them.

## Validation

Ran `docker-compose config` to validate the Compose file renders successfully with the restart policy applied to both services.