### PR TITLE
Add hover tooltips for Related Observatories

### DIFF
--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -384,7 +384,8 @@
                     <span class="metadata-value">
                         {% for obs in software.related_observatories.all %}
                         {% if obs.identifier %}
-                        <a class="tag" href="{{ obs.identifier }}" target="_blank">
+                        <a class="tag" href="{{ obs.identifier }}" target="_blank"
+                           title="View this observatory on {% if 'helio.data.nasa.gov' in obs.identifier %}HelioData{% elif 'spase-metadata.org' in obs.identifier %}SPASE{% else %}an external site{% endif %}">
                             {% if obs.name and obs.name != "UNKNOWN" %}
                             {{ obs.name }}
                             {% else %}


### PR DESCRIPTION
Satisfies Julie's request for tooltips on Related Observatories. Three tooltips are possible now:
- `View this observatory on HelioData`
- `View this observatory on SPASE`
- `View this observatory on an external site` (fallback that won't ever be reached currently because HelioData and SPASE are the only such domains in our DB right now)

## Why
Related Observatory chips on a software's landing page link out to external sites (e.g. HelioData), but—unlike the Related Regions chips—gave no hover text indicating where they'd take you. This adds that text so users know they'll be directed off-site and to which site.

## What
- Adds a native HTML `title` tooltip to each Related Observatory link, matching how Related Regions already renders ("View software filtered by …").
- The destination is named inline from the link's host. A scan of all related-observatory links across HSSI found exactly two hosts: `helio.data.nasa.gov` → "HelioData" and `spase-metadata.org` → "SPASE". A generic "an external site" fallback covers anything else (not reached by current data).

No new files, models, CSS, or JS — a single-line template change.

## Testing
Verified on `http://localhost/software/pyspedas/`: HelioData-backed observatories (ARTEMIS, GOES, MMS, Parker Solar Probe, THEMIS) show "View this observatory on HelioData"; SPASE-backed ones (Arase, POES) show "View this observatory on SPASE". Links still open their external URLs in a new tab.