### PR TITLE
Add Google Analytics (GA4) tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,13 @@ from package.json
 
 * After dependencies are finished installing, simply run `npm run build` to 
 run the build script for the typescript frontend defined in package.json
+
+## Google Analytics
+
+HSSI uses Google Analytics 4 (GA4) to collect anonymous traffic statistics. To enable it, add your GA4 Measurement ID to the `.env` file:
+
+```
+GA_MEASUREMENT_ID="G-XXXXXXXXXX"
+```
+
+The analytics tag is only rendered in production (when `DEBUG` is `False`), so local development traffic is never tracked.

--- a/django/hssi/context_processors.py
+++ b/django/hssi/context_processors.py
@@ -6,4 +6,9 @@ def export_vars(request):
 	data['SITE_DOMAIN'] = settings.SITE_DOMAIN 
 	data['SITE_PROTOCOL'] = settings.SITE_PROTOCOL
 
+	# Only emit the Google Analytics tag in production so local/dev traffic
+	# doesn't pollute the real analytics data.
+	if not settings.DEBUG:
+		data['GA_MEASUREMENT_ID'] = settings.GA_MEASUREMENT_ID
+
 	return data

--- a/django/hssi/settings.py
+++ b/django/hssi/settings.py
@@ -26,6 +26,11 @@ SUPERUSER_PWD = None if 'SUPERUSER_PWD' not in os.environ else os.environ.get('S
 # When unset, the update endpoint denies every request.
 HSSI_UPDATE_TOKEN = os.environ.get("HSSI_UPDATE_TOKEN")
 
+# Google Analytics (GA4) Measurement ID, e.g. "G-XXXXXXXXXX". When unset, the
+# analytics tag is not rendered. Only emitted in production (see
+# context_processors.export_vars) so dev traffic doesn't pollute the data.
+GA_MEASUREMENT_ID = os.environ.get("GA_MEASUREMENT_ID")
+
 ADMIN_EMAIL = "admin@my-site.com"
 DEFAULT_FROM_EMAIL = "noreply@hssi.hsdcloud.org"
 

--- a/django/hssi/templates/site_base_template.html
+++ b/django/hssi/templates/site_base_template.html
@@ -5,6 +5,16 @@
 <html class="no-js" lang="en" dir="ltr" style="overflow: inherit;">
 
 <head>
+	{% if GA_MEASUREMENT_ID %}
+	<!-- Google tag (gtag.js) -->
+	<script async src="https://www.googletagmanager.com/gtag/js?id={{ GA_MEASUREMENT_ID }}"></script>
+	<script>
+		window.dataLayer = window.dataLayer || [];
+		function gtag(){dataLayer.push(arguments);}
+		gtag('js', new Date());
+		gtag('config', '{{ GA_MEASUREMENT_ID }}');
+	</script>
+	{% endif %}
 	<title>{% block title %}HSSI Search{% endblock %}</title>
 	<meta charset="utf-8">
 	<meta http-equiv="x-ua-compatible" content="ie=edge">

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,7 @@ services:
             - GMAIL_EMAIL=${GMAIL_EMAIL}
             - GMAIL_APP_PASSWORD=${GMAIL_APP_PASSWORD}
             - HSSI_UPDATE_TOKEN=${HSSI_UPDATE_TOKEN}
+            - GA_MEASUREMENT_ID=${GA_MEASUREMENT_ID}
             - PROJECT_NAME=hssi
             - APP_NAME=website
             - GUNICORN_WORKERS=4


### PR DESCRIPTION
## What

Adds site-wide Google Analytics 4 tracking via the gtag.js tag, rendered from the shared base template so every page is covered from a single insertion point. The GA4 property is set up under the hssi.hsdcloud.org@gmail.com Google Account that Isaiah created for us.

## How it's wired

The Measurement ID comes from a `GA_MEASUREMENT_ID` environment variable rather than being hardcoded, following the same pattern as the existing `GMAIL_*` and `HSSI_UPDATE_TOKEN` config:

- `settings.py` reads `GA_MEASUREMENT_ID` from the environment.
- `context_processors.export_vars` exposes it to templates, but only when `DEBUG` is `False`.
- `site_base_template.html` renders the gtag.js snippet in `<head>`, guarded by `{% if GA_MEASUREMENT_ID %}`.
- `docker-compose.yml` passes the variable through to the container.
- `README.md` documents the new variable.

## Production-only by design

Because local development always runs with `SITE_DOMAIN = "localhost"` (and therefore `DEBUG = True`), gating the tag on `not DEBUG` keeps dev and test traffic out of the analytics data entirely — the tag isn't present in the page at all on localhost. `not DEBUG` is the same signal the codebase already uses to decide `ALLOWED_HOSTS` and template caching.

## Deployment note

The `.env` file is gitignored, so this PR does not include the actual Measurement ID. To activate tracking, set `GA_MEASUREMENT_ID="G-XXXXXXXXXX"` in the production environment and restart.
