### PR TITLE
Add GA custom events for search terms and resource submissions

### DIFF
--- a/django/website/templates/website/software_detail.html
+++ b/django/website/templates/website/software_detail.html
@@ -706,6 +706,20 @@ document.querySelectorAll('details.software-section').forEach(details => {
         }
     });
 });
+
+// Report Request-Edit-Access clicks to GA. This is a <button> (not a link), so
+// GA's enhanced measurement won't auto-track it; the software name lets each
+// click be attributed to the package whose page it fired on.
+(function() {
+    var editBtn = document.querySelector('.btn-request-edit');
+    if (editBtn && typeof gtag === 'function') {
+        editBtn.addEventListener('click', function() {
+            gtag('event', 'resource_edit_requested', {
+                software_name: '{{ software.software_name|escapejs }}',
+            });
+        });
+    }
+})();
 </script>
 
 {% if software.persistent_identifier or software.reference_publication and software.reference_publication.identifier %}
@@ -713,6 +727,13 @@ document.querySelectorAll('details.software-section').forEach(details => {
 (function() {
     var section = document.querySelector('.citation-section');
     if (!section) return;
+
+    // Public software name only (never PII), attached to GA events below so
+    // each click is attributable to the package whose page it fired on.
+    var gaSoftwareName = '{{ software.software_name|escapejs }}';
+    function trackGaEvent(name, params) {
+        if (typeof gtag === 'function') gtag('event', name, params);
+    }
 
     var doi = section.dataset.doi || '';
     var refDoi = section.dataset.refDoi || '';
@@ -837,12 +858,20 @@ document.querySelectorAll('details.software-section').forEach(details => {
     if (copySoftwareBtn) {
         copySoftwareBtn.addEventListener('click', function() {
             copyToClipboard(this, softwareEl.innerText, this.title);
+            trackGaEvent('citation_copied', {
+                software_name: gaSoftwareName,
+                citation_type: 'software',
+            });
         });
     }
 
     if (copyRefpubBtn) {
         copyRefpubBtn.addEventListener('click', function() {
             copyToClipboard(this, refpubEl.innerText, this.title);
+            trackGaEvent('citation_copied', {
+                software_name: gaSoftwareName,
+                citation_type: 'reference_publication',
+            });
         });
     }
 
@@ -852,6 +881,7 @@ document.querySelectorAll('details.software-section').forEach(details => {
         citeBtn.addEventListener('click', function() {
             if (section.classList.contains('citation-hidden')) {
                 section.classList.remove('citation-hidden');
+                trackGaEvent('cite_me_open', { software_name: gaSoftwareName });
                 if (!loaded) {
                     fetchAll(styleSelect.value);
                     loaded = true;

--- a/frontend/filters/search.ts
+++ b/frontend/filters/search.ts
@@ -7,6 +7,7 @@ import {
 	ResourceView,
 	Spinner, 
 	fetchTimeout,
+	trackEvent,
 } from "../loader";
 
 export const idSearchbar = "searchbar";
@@ -133,6 +134,13 @@ export async function searchForQuery(
 		view.showItems(filteredResults);
 		
 		if (pushHistory) recordHistory(trimmedQuery);
+
+		// Report user-initiated searches to GA (pushHistory is false when we're
+		// just restoring a search from the URL, which GA's enhanced measurement
+		// already captures on full page loads — avoids double counting).
+		if (pushHistory) {
+			trackEvent("view_search_results", { search_term: trimmedQuery });
+		}
 		
 		console.log(`queried '${trimmedQuery}', results:`, filteredResults);	
 

--- a/frontend/filters/search.ts
+++ b/frontend/filters/search.ts
@@ -136,8 +136,9 @@ export async function searchForQuery(
 		if (pushHistory) recordHistory(trimmedQuery);
 
 		// Report user-initiated searches to GA (pushHistory is false when we're
-		// just restoring a search from the URL, which GA's enhanced measurement
-		// already captures on full page loads — avoids double counting).
+		// restoring or reapplying an existing URL search — e.g. a full page load
+		// that GA's enhanced measurement already captures, or a filter change
+		// reapplying the current query — so this avoids double counting).
 		if (pushHistory) {
 			trackEvent("view_search_results", { search_term: trimmedQuery });
 		}

--- a/frontend/forms/formGenerator.ts
+++ b/frontend/forms/formGenerator.ts
@@ -7,6 +7,7 @@ import {
 	UrlWidget,
 	EmailWidget,
 	PopupDialogue,
+	trackEvent,
 } from "../loader";
 
 const generatedFormType = "generated-form";
@@ -199,7 +200,27 @@ export class FormGenerator {
 		// we don't want the default html form functionality submitting anything
 		e.preventDefault();
 
-		if(!this.validateForSubmission()) return;
+		// Captured once here (the value typed at submit time) and attached to
+		// every submission event below. Public package name only — never PII.
+		const softwareName = this.getRootFields()
+			.find(f => f.name === "software_name")
+			?.getInputElement()?.value ?? "";
+
+		// Fire on every Submit click, before validation, so we capture attempts
+		// even when they fail client-side validation.
+		trackEvent("resource_submit_attempt", {
+			form_type: this.isEditForm ? "edit" : "new",
+			software_name: softwareName,
+		});
+
+		if(!this.validateForSubmission()){
+			trackEvent("resource_submit_failed", {
+				form_type: this.isEditForm ? "edit" : "new",
+				software_name: softwareName,
+				reason: "validation",
+			});
+			return;
+		}
 
 		Spinner.showSpinner();
 
@@ -237,6 +258,20 @@ export class FormGenerator {
 					"We encountered an error, please try again later.",
 					"Error", "ok", null
 				);
+				trackEvent("resource_submit_failed", {
+					form_type: this.isEditForm ? "edit" : "new",
+					software_name: softwareName,
+					reason: "server_error",
+				});
+			}
+			else {
+				// Successful submission — the reliable success signal for GA,
+				// since the form posts via fetch() + preventDefault, so GA's
+				// automatic form_submit does not fire.
+				trackEvent("resource_submitted", {
+					form_type: this.isEditForm ? "edit" : "new",
+					software_name: softwareName,
+				});
 			}
 
 			if(response.redirected) window.location.href = response.url;
@@ -247,6 +282,11 @@ export class FormGenerator {
 				"We encountered an error, please try again later. \n" + String(e),
 				"Error", "ok", null
 			);
+			trackEvent("resource_submit_failed", {
+				form_type: this.isEditForm ? "edit" : "new",
+				software_name: softwareName,
+				reason: "network_error",
+			});
 		});
 		response.finally(async () => {
 			Spinner.hideSpinner();

--- a/frontend/forms/formGenerator.ts
+++ b/frontend/forms/formGenerator.ts
@@ -269,10 +269,10 @@ export class FormGenerator {
 
 			// Successful submission — the reliable success signal for GA, since
 			// the form posts via fetch() + preventDefault so GA's automatic
-			// form_submit doesn't fire. Defer the redirect until GA has sent this
-			// conversion (or a short fallback fires), so navigating away doesn't
-			// cancel it. Edit forms navigate via the finally() dialog instead, so
-			// response.redirected is normally false for them.
+			// form_submit doesn't fire. Defer the redirect until GA has processed
+			// this conversion event (or a short fallback fires), so navigating
+			// away doesn't cancel it. Edit forms navigate via the finally() dialog
+			// instead, so response.redirected is normally false for them.
 			trackEvent(
 				"resource_submitted",
 				{

--- a/frontend/forms/formGenerator.ts
+++ b/frontend/forms/formGenerator.ts
@@ -200,10 +200,8 @@ export class FormGenerator {
 		// we don't want the default html form functionality submitting anything
 		e.preventDefault();
 
-		// Captured once at submit time and attached only to the successful
-		// submission event below — by then it's a server-accepted public package
-		// name. Pre-validation attempts and failures deliberately omit it: the
-		// field is still raw user input there, and GA must not receive PII.
+		// Captured once at submit time and attached to every submission event
+		// below — the public package name typed into the form.
 		const softwareName = this.getRootFields()
 			.find(f => f.name === "software_name")
 			?.getInputElement()?.value ?? "";
@@ -212,11 +210,13 @@ export class FormGenerator {
 		// even when they fail client-side validation.
 		trackEvent("resource_submit_attempt", {
 			form_type: this.isEditForm ? "edit" : "new",
+			software_name: softwareName,
 		});
 
 		if(!this.validateForSubmission()){
 			trackEvent("resource_submit_failed", {
 				form_type: this.isEditForm ? "edit" : "new",
+				software_name: softwareName,
 				reason: "validation",
 			});
 			return;
@@ -260,6 +260,7 @@ export class FormGenerator {
 				);
 				trackEvent("resource_submit_failed", {
 					form_type: this.isEditForm ? "edit" : "new",
+					software_name: softwareName,
 					reason: "server_error",
 				});
 				if(response.redirected) window.location.href = response.url;
@@ -289,6 +290,7 @@ export class FormGenerator {
 			);
 			trackEvent("resource_submit_failed", {
 				form_type: this.isEditForm ? "edit" : "new",
+				software_name: softwareName,
 				reason: "network_error",
 			});
 		});

--- a/frontend/forms/formGenerator.ts
+++ b/frontend/forms/formGenerator.ts
@@ -200,8 +200,10 @@ export class FormGenerator {
 		// we don't want the default html form functionality submitting anything
 		e.preventDefault();
 
-		// Captured once here (the value typed at submit time) and attached to
-		// every submission event below. Public package name only — never PII.
+		// Captured once at submit time and attached only to the successful
+		// submission event below — by then it's a server-accepted public package
+		// name. Pre-validation attempts and failures deliberately omit it: the
+		// field is still raw user input there, and GA must not receive PII.
 		const softwareName = this.getRootFields()
 			.find(f => f.name === "software_name")
 			?.getInputElement()?.value ?? "";
@@ -210,13 +212,11 @@ export class FormGenerator {
 		// even when they fail client-side validation.
 		trackEvent("resource_submit_attempt", {
 			form_type: this.isEditForm ? "edit" : "new",
-			software_name: softwareName,
 		});
 
 		if(!this.validateForSubmission()){
 			trackEvent("resource_submit_failed", {
 				form_type: this.isEditForm ? "edit" : "new",
-				software_name: softwareName,
 				reason: "validation",
 			});
 			return;
@@ -260,21 +260,26 @@ export class FormGenerator {
 				);
 				trackEvent("resource_submit_failed", {
 					form_type: this.isEditForm ? "edit" : "new",
-					software_name: softwareName,
 					reason: "server_error",
 				});
-			}
-			else {
-				// Successful submission — the reliable success signal for GA,
-				// since the form posts via fetch() + preventDefault, so GA's
-				// automatic form_submit does not fire.
-				trackEvent("resource_submitted", {
-					form_type: this.isEditForm ? "edit" : "new",
-					software_name: softwareName,
-				});
+				if(response.redirected) window.location.href = response.url;
+				return;
 			}
 
-			if(response.redirected) window.location.href = response.url;
+			// Successful submission — the reliable success signal for GA, since
+			// the form posts via fetch() + preventDefault so GA's automatic
+			// form_submit doesn't fire. Defer the redirect until GA has sent this
+			// conversion (or a short fallback fires), so navigating away doesn't
+			// cancel it. Edit forms navigate via the finally() dialog instead, so
+			// response.redirected is normally false for them.
+			trackEvent(
+				"resource_submitted",
+				{
+					form_type: this.isEditForm ? "edit" : "new",
+					software_name: softwareName,
+				},
+				() => { if(response.redirected) window.location.href = response.url; }
+			);
 		});
 		response.catch(e => {
 			Spinner.hideSpinner();
@@ -284,7 +289,6 @@ export class FormGenerator {
 			);
 			trackEvent("resource_submit_failed", {
 				form_type: this.isEditForm ? "edit" : "new",
-				software_name: softwareName,
 				reason: "network_error",
 			});
 		});

--- a/frontend/util.ts
+++ b/frontend/util.ts
@@ -35,11 +35,12 @@ export function getCsrfTokenValue(): string {
  * only rendered in production (see hssi/templates/site_base_template.html), so
  * on local/dev builds `gtag` is undefined and this is a safe no-op.
  *
- * Pass `onComplete` when you need to act only after the event has been sent —
- * e.g. redirecting right after a conversion, where navigating away could
- * otherwise cancel the in-flight event. It runs via GA's `event_callback`, but
- * is guarded to fire exactly once and to still run (after a short fallback) if
- * GA never calls back or isn't present at all, so callers are never stranded.
+ * Pass `onComplete` when you need to act only after GA has processed the event
+ * command — e.g. redirecting right after a conversion, where navigating away
+ * too early could otherwise cancel the in-flight event. It runs via GA's
+ * `event_callback`, but is guarded to fire exactly once and to still run (after
+ * a short fallback) if GA never calls back or isn't present at all, so callers
+ * are never stranded.
  */
 export function trackEvent(
 	name: string,

--- a/frontend/util.ts
+++ b/frontend/util.ts
@@ -34,13 +34,39 @@ export function getCsrfTokenValue(): string {
  * Send a custom event to Google Analytics, if the GA tag is present. The tag is
  * only rendered in production (see hssi/templates/site_base_template.html), so
  * on local/dev builds `gtag` is undefined and this is a safe no-op.
+ *
+ * Pass `onComplete` when you need to act only after the event has been sent —
+ * e.g. redirecting right after a conversion, where navigating away could
+ * otherwise cancel the in-flight event. It runs via GA's `event_callback`, but
+ * is guarded to fire exactly once and to still run (after a short fallback) if
+ * GA never calls back or isn't present at all, so callers are never stranded.
  */
 export function trackEvent(
 	name: string,
-	params: Record<string, unknown> = {}
+	params: Record<string, unknown> = {},
+	onComplete?: () => void
 ): void {
 	const gtag = (window as any).gtag;
-	if (typeof gtag === "function") gtag("event", name, params);
+
+	if (typeof gtag !== "function") {
+		if (onComplete) onComplete();
+		return;
+	}
+
+	if (!onComplete) {
+		gtag("event", name, params);
+		return;
+	}
+
+	let done = false;
+	const finish = () => {
+		if (done) return;
+		done = true;
+		onComplete();
+	};
+	const timeoutMs = 2000;
+	gtag("event", name, { ...params, event_callback: finish, event_timeout: timeoutMs });
+	setTimeout(finish, timeoutMs);
 }
 
 /**

--- a/frontend/util.ts
+++ b/frontend/util.ts
@@ -31,6 +31,19 @@ export function getCsrfTokenValue(): string {
 }
 
 /**
+ * Send a custom event to Google Analytics, if the GA tag is present. The tag is
+ * only rendered in production (see hssi/templates/site_base_template.html), so
+ * on local/dev builds `gtag` is undefined and this is a safe no-op.
+ */
+export function trackEvent(
+	name: string,
+	params: Record<string, unknown> = {}
+): void {
+	const gtag = (window as any).gtag;
+	if (typeof gtag === "function") gtag("event", name, params);
+}
+
+/**
  * merge two objects together, recursively
  * @param target merge into this object
  * @param source values from this object will overwrite target values


### PR DESCRIPTION
## What

Adds custom Google Analytics events for the interactions GA4 doesn't capture on its own — site searches, Submit-a-Resource usage, and a few high-intent buttons on software landing pages — building on the GA tag from #42. The TypeScript-side events (search + form) route through a small shared `trackEvent()` helper in `util.ts` that no-ops when `window.gtag` is absent; the software-detail button events live in that page's inline `<script>` rather than the bundle, so they use an equivalent guarded `gtag('event', …)` call. Either way, local/dev builds (where the tag isn't rendered) are unaffected.

## What's captured: before vs. after

| Interaction | Default GA4 (no changes) | After this PR |
|---|---|---|
| Page views — incl. each software landing page (distinct path + title) | ✅ Captured | ✅ Unchanged |
| Scroll depth / outbound clicks / file downloads | ✅ Enhanced measurement | ✅ Unchanged |
| Action-bar links (Code / Docs / Publication / DOI / SciX) | ✅ Auto-tracked outbound `click` (with URL) | ✅ Unchanged — no new event needed |
| Direct load of a `?q=` search URL | ✅ `view_search_results` + `search_term` | ✅ Unchanged (no double-count) |
| Search via the search bar (SPA) | ⚠️ Only a `page_view` (term in title); no `search_term` | ✅ `view_search_results` + `search_term` |
| "Submit" clicked (any outcome) | ❌ Nothing | ✅ `resource_submit_attempt` |
| Submission **succeeded** | ❌ `form_submit` doesn't fire reliably | ✅ `resource_submitted` |
| Submission **failed** (validation / server / network) | ❌ Nothing | ✅ `resource_submit_failed` (`reason`) |
| "Cite Me" opens the citation panel | ❌ Nothing (a button, not a link) | ✅ `cite_me_open` |
| Citation copy button clicked | ❌ Nothing | ✅ `citation_copied` (`citation_type`) |
| "Request Edit Access" clicked | ❌ Nothing (a button, not a link) | ✅ `resource_edit_requested` |
| *What* was submitted / attempted / cited | ❌ Nothing | ✅ `software_name` (the public package name) on submit + cite events |
| Other form field contents (names, emails, …) | ❌ Never | ❌ Never — deliberately excluded (PII) |

## The new events

Search and form (TypeScript, via `trackEvent()`):

- **`view_search_results`** (`search_term`) — `search.ts`, on user-initiated searches. Gated on the existing `pushHistory` flag (false only when restoring a search from the URL), so the live SPA search bar is covered without double-counting the enhanced-measurement event that already fires on full `?q=` page loads. Uses GA4's standard event name, so it feeds the built-in Site search report.
- **`resource_submit_attempt`** — every Submit click, before validation (captures failed attempts too).
- **`resource_submitted`** — a submission that succeeded. As the conversion event it's sent with GA's `event_callback`, and the post-submit redirect waits for that callback (with a short timeout fallback, and an immediate run when GA is absent) so navigating away can't cancel it.
- **`resource_submit_failed`** (`reason`: `validation` | `server_error` | `network_error`) — a submission that failed, and why.

Each submit event carries `form_type` (`new` vs `edit`) and `software_name` — the public package name, captured once at submit time — so you can see *what* is being submitted/attempted. No other field contents are sent, so no PII (submitter/author names, emails) leaves the browser.

Software-detail buttons (inline page script, via a guarded `gtag('event', …)`):

- **`cite_me_open`** (`software_name`) — when the "Cite Me" button opens the citation panel; fires on open only, not on close, to avoid toggle noise.
- **`citation_copied`** (`software_name`, `citation_type`: `software` | `reference_publication`) — when a citation copy button is clicked; the strongest "intent to cite" signal.
- **`resource_edit_requested`** (`software_name`) — when "Request Edit Access" is clicked; the top of the edit funnel that `resource_submit_*` with `form_type=edit` already completes.

These three live in inline page scripts rather than the bundle, so they don't use `trackEvent()` and need no frontend rebuild. The link-style action buttons (Code, Docs, Publication, DOI, SciX) are `target="_blank"` outbound links that enhanced measurement already auto-tracks as `click` events with the destination URL, so they get no extra event. Each carries the public `software_name` (`{{ software.software_name }}`, a server-rendered published catalog name rather than raw input), so events are attributable per package.

## Why explicit submit events (educated guess on real submissions)

A live submission can't be safely tested here, so I traced the code:
- The form is a real `<form>` with `<input type="submit">` and uses custom (`data-hssi-required`) validation, not native `required` — so Submit dispatches a native `submit` event even with blank fields.
- But `onSubmit` calls `e.preventDefault()` on every submission and posts via `fetch()`. GA4's automatic `form_submit` doesn't reliably fire for forms that cancel the native submit and post over JS.
- The live test matches: a real `submit` event fired on a blank-field click, yet GA logged no `form_submit`.

So even successful real submissions almost certainly won't trigger GA's automatic `form_submit` — hence the explicit events. Worth confirming with one real/staging submission post-deploy.

## Notes

- The search and form events are source-only; the compiled bundle (`django/static/js/compiled/`) is gitignored and must be rebuilt with `npm run build` before deploy (the deploy doesn't run it automatically). The software-detail button events are inline template JS, so they take effect without a rebuild.
- The "free in GA4" rows above assume Enhanced Measurement is enabled on the GA data stream (it is by default, but individual toggles — outbound clicks, site search, scroll — can be turned off). Worth a one-time confirm in GA → Admin → Data Streams → Enhanced measurement.

## Remaining tasks

- [x] **Register custom dimensions in GA** (Admin → Custom definitions) for `form_type`, `software_name`, `reason`, and `citation_type` — done; all four are registered as event-scoped dimensions with matching parameter names. (`search_term` is standard and needs no setup.)
- [x] *(Optional, post-deploy)* Mark `resource_submitted` as a **key event** (conversion) by starring it in Admin → Events → Recent events. GA no longer supports registering a key event by name ahead of time, so this can only be done after the event has fired at least once in production (e.g. one real or test submission). — Done: `resource_submitted` fired in production and is now marked as a key event in GA.
- [x] *(Optional)* Confirm GA's automatic `form_submit` really doesn't fire, with one real or staging submission. — Confirmed it does not fire: `form_start` fires (GA form-interaction tracking is enabled), but the form posts via `fetch()` + `preventDefault` and never natively submits, so GA's automatic `form_submit` never triggers — the reason the explicit `resource_submitted` event exists.




