### PR TITLE
Change SunPy and HAPI Client landing-page slugs to sunpy / hapi-client

### DIFF
--- a/django/website/config/db/verified_software.csv
+++ b/django/website/config/db/verified_software.csv
@@ -51,13 +51,13 @@ d0dcf8b7-d032-481b-b80e-dea683cc1fa4,spiceypy
 ecd7fb7a-570b-4466-b0ea-8d4b60016036,stokespy
 110491fc-f060-4b9d-ab2c-bb0806824948,sunkit-image
 db2bcb8a-c799-4233-9699-dea23b975972,sunkit-instruments
-13b71402-f2cb-4aa3-9b17-639652e87ca8,sunpy-a-core-package-for-solar-physics
+13b71402-f2cb-4aa3-9b17-639652e87ca8,sunpy
 52e4975a-0d6d-4bb0-91a3-862f8e113091,swmf
 1fd6fa60-cd5d-4e38-bfea-ea8dc5b25eaa,swxsoc
 52d61c70-77fd-4c4a-aae8-f4e24dde6de8,tiegcm-v3-0
 15e95cb0-2008-4b98-83e9-0ce5a614b42c,viresclient
 a562afcf-b6f7-4ddd-be72-d450f8de9fc0,vswim
-f6e3429d-e80e-4cf6-889e-44af1e93f87d,hapi-server-client-python
+f6e3429d-e80e-4cf6-889e-44af1e93f87d,hapi-client
 ac1149e1-6679-4466-a445-1f6dd0ecd883,magnetospheric-swcx
 fd58b98f-87d6-441b-bec8-aa79752f3c5e,sammi-cdf
 c9f100c2-e502-4a61-94d5-87ae0f4d3646,solarmach


### PR DESCRIPTION
Updates two landing-page URL slugs to match the packages' simplified names.

| software | UUID | old slug | new slug |
|---|---|---|---|
| SunPy | `13b71402-…` | `sunpy-a-core-package-for-solar-physics` | `sunpy` |
| HAPI Client | `f6e3429d-…` | `hapi-server-client-python` | `hapi-client` |

## Why
The slug (`VerifiedSoftware.slug`) is computed **once** at verification time (`get_unique_slug`, called only from `create_verified`) and is never recomputed when a software is renamed. After the recent name simplifications the slugs stayed frozen on the old long names, so the landing pages still live at e.g. `/software/sunpy-a-core-package-for-solar-physics/`. The slug isn't an API-patchable field, so this seed-CSV edit + DB re-import is the version-controlled way to change it.

## Scope / notes
- One file, two cells in `verified_software.csv`. Both new slugs are unique.
- **Old URLs will 404** after the import — there's no old-slug→new-slug redirect in the app today (only a pk→slug 301). This is accepted for now.
- Takes effect on production only after the seed CSVs are re-imported.
