### PR TITLE
fix: use 302 (not 301) for UUID->slug redirect so renames don't strand cached browsers

### DIFF
--- a/django/website/tests.py
+++ b/django/website/tests.py
@@ -145,7 +145,7 @@ class SoftwareDetailJsonLdTests(TestCase):
 		uuid_url = reverse("website:software_detail", kwargs={"pk": software.pk})
 		url = software.get_absolute_url()
 		redirect_response = self.client.get(uuid_url)
-		self.assertEqual(redirect_response.status_code, 301)
+		self.assertEqual(redirect_response.status_code, 302)
 		self.assertEqual(redirect_response["Location"], url)
 
 		response = self.client.get(url)

--- a/django/website/views/software_detail.py
+++ b/django/website/views/software_detail.py
@@ -8,7 +8,7 @@ from django.db.models import QuerySet
 from django.urls import reverse
 from django.utils.safestring import mark_safe
 from django.views import generic
-from django.http import Http404, HttpResponsePermanentRedirect
+from django.http import Http404, HttpResponseRedirect
 
 from ..models import Software, VerifiedSoftware, SoftwareVersion
 from ..models.serializers.software import SoftwareSerializer
@@ -29,7 +29,9 @@ class SoftwareDetailView(generic.DetailView):
             pk = self.kwargs.get('pk')
             software = VerifiedSoftware.objects.filter(pk=pk).first()
             if software:
-                return HttpResponsePermanentRedirect(
+                # 302 (temporary) on purpose: a 301 would be cached by browsers and
+                # strand them on a stale slug whenever a software is later renamed.
+                return HttpResponseRedirect(
                     reverse('website:software_detail', kwargs={'slug': software.slug})
                 )
         return super().get(request, *args, **kwargs)


### PR DESCRIPTION
## Problem
`/software/<uuid>/` returns a **301 permanent** redirect to the software's slug URL (`SoftwareDetailView.get`). Browsers cache 301s indefinitely, so after a software is renamed (its slug changes), any browser that cached the old `uuid → old-slug` redirect keeps navigating straight to the now-dead old slug and gets a 404 — never re-asking the server. Homepage cards link by UUID (`frontend/resources/resourceItem.ts`) and rely on this redirect, so the breakage shows up on normal card clicks for returning visitors.

This surfaced right after the SunPy / HAPI Client slug rename: e.g. `/software/13b71402-…/` → (cached 301) → `/software/sunpy-a-core-package-for-solar-physics/` → 404, even though the server now correctly redirects fresh requests to `/software/sunpy/`.

## Fix
Switch the UUID→slug redirect from `HttpResponsePermanentRedirect` (301) to `HttpResponseRedirect` (302 temporary), so the mapping is re-resolved on every navigation and future renames never strand cached clients. Updated the test that asserted 301.

## Notes
- Does not retroactively evict already-cached 301s in existing browsers — those self-heal as each browser's cache expires (or via a cache clear). This prevents the problem recurring on future renames.
- Old long-slug URLs still 404 (no old-slug→new-slug redirect; that was a deliberate scope decision).
- `website.tests.SoftwareDetailJsonLdTests` passes locally (2 tests).
