### PR TITLE
Add software version checker (detect out-of-date GitHub releases)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,47 @@ GA_MEASUREMENT_ID="G-XXXXXXXXXX"
 ```
 
 The analytics tag is only rendered in production (when `DEBUG` is `False`), so local development traffic is never tracked.
+
+## Software Version Checker
+
+The `check_software_versions` management command detects when GitHub-hosted
+software listed in HSSI has published a newer release than the version HSSI
+currently records. It is adapted from EMAC's `git_fetch_version`, but **defaults
+to detection only** — it reports what is out of date and writes nothing unless
+you explicitly opt in with `--apply`.
+
+Run it from inside the app container:
+
+```
+docker exec HSSI sh -c 'cd /django && python manage.py check_software_versions'
+```
+
+Options:
+
+* `--apply` — opt-in; create a new `SoftwareVersion` for each out-of-date entry
+  and point the software at it. Off by default (detection only).
+* `--csv PATH` — also write the out-of-date report to a CSV file.
+* `--limit N` — only check the first N github-hosted software (useful for testing).
+* `--github-token TOKEN` — GitHub token for a higher API rate limit. Falls back
+  to the `GITHUB_TOKEN` environment variable.
+
+GitHub's anonymous API is limited to 60 requests/hour, which is easily exhausted
+on a shared IP (the command will report `HTTP 403/429` rate-limit errors). Supply
+a token to raise the limit to 5000 requests/hour:
+
+```
+docker exec -e GITHUB_TOKEN=ghp_xxx HSSI sh -c 'cd /django && python manage.py check_software_versions'
+```
+
+A token needs no special scopes — read access to public repositories is enough.
+
+Detection rules:
+
+* A software is reported as out-of-date when its repository's highest-numbered
+  GitHub release is **strictly newer** than the version HSSI records. An older
+  release that was merely published more recently (e.g. a back-ported patch) is
+  not treated as an update.
+* A software with **no version recorded at all** is also reported, with the latest
+  git release suggested as the version to apply.
+* Software whose repository has no GitHub releases is counted separately (there is
+  nothing to suggest) and is not reported as out-of-date.

--- a/django/website/management/commands/check_software_versions.py
+++ b/django/website/management/commands/check_software_versions.py
@@ -40,20 +40,12 @@ GITHUB_API = "https://api.github.com"
 def version_tuple(version: str) -> tuple[int, ...]:
 	"""Extract a comparable numeric tuple from a version/tag string.
 
-	Strips everything except digits and dots — so ``v1.2``, ``kaipy-1.1.4`` and
-	``TIEGCM-3.0.1`` reduce to their numeric components — then splits on dots.
+	Pulls out each maximal run of digits — so ``v1.2``, ``kaipy-1.1.4``,
+	``TIEGCM-3.0.1`` and even ``0.2b1`` / ``VAPOR3_1_0_RC0`` reduce to their
+	numeric components without letters merging adjacent digits together.
 	Returns an empty tuple when there is no numeric component.
 	"""
-	cleaned = re.sub(r"[^\d\.]", "", version or "").strip(".")
-	parts: list[int] = []
-	for chunk in cleaned.split("."):
-		if chunk == "":
-			continue
-		try:
-			parts.append(int(chunk))
-		except ValueError:
-			pass
-	return tuple(parts)
+	return tuple(int(run) for run in re.findall(r"\d+", version or ""))
 
 
 def is_newer(candidate: str, current: str) -> bool:
@@ -154,13 +146,17 @@ def fetch_latest_release(
 	repo: str,
 	token: str | None,
 ) -> ReleaseInfo | None:
-	"""Return the highest-version release for ``owner/repo``, or None if none exist.
+	"""Return the latest stable release for ``owner/repo``, or None if none exist.
 
 	GitHub returns the releases list ordered by publish date, so the first entry is
 	not necessarily the highest version (a back-ported patch to an older line can be
 	published after a newer release). We therefore pick the release with the highest
-	numeric version among all non-draft releases, so the caller compares against the
-	true latest version rather than merely the most recently published one.
+	numeric version, so the caller compares against the true latest version rather
+	than merely the most recently published one.
+
+	Drafts are skipped, and full releases are preferred over pre-releases: a
+	pre-release (beta/RC) is only considered when the repository has no full release
+	at all. This avoids surfacing an old beta as the "latest" version.
 
 	Raises ``requests.HTTPError`` (via ``raise_for_status``) on a non-2xx response
 	so the caller can record the failure per-software without aborting the run.
@@ -180,9 +176,8 @@ def fetch_latest_release(
 	if not releases:
 		return None
 
-	best = None
-	best_tag = ""
-	best_tuple: tuple[int, ...] | None = None
+	finals: list[tuple[tuple[int, ...], str, dict]] = []
+	prereleases: list[tuple[tuple[int, ...], str, dict]] = []
 	for rel in releases:
 		if rel.get("draft"):
 			continue
@@ -195,14 +190,14 @@ def fetch_latest_release(
 		)
 		if not tag:
 			continue
-		candidate_tuple = version_tuple(tag)
-		if best is None or candidate_tuple > best_tuple:
-			best = rel
-			best_tag = tag
-			best_tuple = candidate_tuple
+		entry = (version_tuple(tag), tag, rel)
+		(prereleases if rel.get("prerelease") else finals).append(entry)
 
-	if best is None:
+	# Prefer full releases; fall back to pre-releases only if there are no finals.
+	pool = finals or prereleases
+	if not pool:
 		return None
+	_, best_tag, best = max(pool, key=lambda entry: entry[0])
 	return ReleaseInfo(
 		tag=best_tag,
 		notes=best.get("body") or "",

--- a/django/website/management/commands/check_software_versions.py
+++ b/django/website/management/commands/check_software_versions.py
@@ -1,0 +1,450 @@
+"""Detect (and optionally apply) new GitHub releases for HSSI software.
+
+Ported in spirit from EMAC's ``git_fetch_version`` view, but reworked for HSSI:
+
+* Reads software directly via the ORM (no HTTP API needed).
+* **Defaults to detection only** — it reports which GitHub-hosted software have a
+  newer release than what HSSI currently records, and writes nothing.
+* ``--apply`` (opt-in) creates a new ``SoftwareVersion`` for each out-of-date entry
+  and points the software at it. This is intentionally off by default.
+
+Usage examples (run from the ``django`` directory or inside the app container)::
+
+    python manage.py check_software_versions
+    python manage.py check_software_versions --csv /tmp/outdated.csv
+    python manage.py check_software_versions --limit 5
+    python manage.py check_software_versions --apply        # opt-in: writes to the DB
+
+A GitHub token may be supplied with ``--github-token`` or the ``GITHUB_TOKEN``
+environment variable to raise the API rate limit (anonymous is 60 requests/hour).
+"""
+
+from __future__ import annotations
+
+import csv as csv_module
+import datetime
+import os
+import re
+import traceback
+from dataclasses import dataclass, field
+
+import requests
+from django.core.management.base import BaseCommand, CommandError
+
+from website.models import Software, SoftwareVersion
+
+
+GITHUB_API = "https://api.github.com"
+
+
+def version_tuple(version: str) -> tuple[int, ...]:
+	"""Extract a comparable numeric tuple from a version/tag string.
+
+	Strips everything except digits and dots — so ``v1.2``, ``kaipy-1.1.4`` and
+	``TIEGCM-3.0.1`` reduce to their numeric components — then splits on dots.
+	Returns an empty tuple when there is no numeric component.
+	"""
+	cleaned = re.sub(r"[^\d\.]", "", version or "").strip(".")
+	parts: list[int] = []
+	for chunk in cleaned.split("."):
+		if chunk == "":
+			continue
+		try:
+			parts.append(int(chunk))
+		except ValueError:
+			pass
+	return tuple(parts)
+
+
+def is_newer(candidate: str, current: str) -> bool:
+	"""Return True if ``candidate`` is a strictly higher version than ``current``.
+
+	Zero-pads the shorter tuple so e.g. ``v1.1`` and ``1.1.0`` compare equal (and
+	are therefore *not* newer), while ``1.1.1`` is newer than ``1.1``. This is what
+	prevents an older release that happens to be published more recently (a
+	*downgrade*, e.g. a back-ported patch) from being reported as an update.
+	"""
+	cand = version_tuple(candidate)
+	cur = version_tuple(current)
+	length = max(len(cand), len(cur))
+	cand += (0,) * (length - len(cand))
+	cur += (0,) * (length - len(cur))
+	return cand > cur
+
+
+def parse_owner_repo(repo_url: str) -> tuple[str, str] | None:
+	"""Extract ``(owner, repo)`` from a github.com URL, or None if not parseable."""
+	if not repo_url or "github.com" not in repo_url:
+		return None
+	try:
+		after = repo_url.split("github.com/", 1)[1]
+	except IndexError:
+		return None
+	parts = [p for p in after.strip("/").split("/") if p]
+	if len(parts) < 2:
+		return None
+	owner = parts[0]
+	repo = parts[1]
+	if repo.endswith(".git"):
+		repo = repo[:-len(".git")]
+	return owner, repo
+
+
+def current_version_number(software: Software) -> str:
+	"""Return the software's current recorded version number.
+
+	Mirrors ``SoftwareSerializer._latest_version`` so detection matches what the
+	site shows: prefer the version with the latest ``release_date``, otherwise the
+	highest ``number`` by string sort. Empty string when no version is recorded.
+	"""
+	versions = list(software.version.all())
+	if not versions:
+		return ""
+	with_dates = [v for v in versions if v.release_date]
+	if with_dates:
+		return max(with_dates, key=lambda v: v.release_date).number or ""
+	return (sorted(versions, key=lambda v: v.number)[-1].number) or ""
+
+
+@dataclass
+class ReleaseInfo:
+	"""The bits of a GitHub release we care about."""
+	tag: str
+	notes: str
+	published_at: str | None
+
+	def release_date(self) -> datetime.date | None:
+		if not self.published_at:
+			return None
+		try:
+			return datetime.datetime.strptime(
+				self.published_at[:10], "%Y-%m-%d"
+			).date()
+		except (ValueError, TypeError):
+			return None
+
+
+@dataclass
+class Outdated:
+	"""A software entry that should adopt a newer (or any) GitHub release.
+
+	``missing_version`` is True when HSSI has no version recorded at all — every
+	software should have a version, so we flag these and suggest the latest git
+	release even though there is nothing to compare against.
+	"""
+	software: Software
+	current: str
+	release: ReleaseInfo
+	missing_version: bool = False
+
+
+@dataclass
+class CheckResult:
+	outdated: list[Outdated] = field(default_factory=list)
+	checked: int = 0
+	up_to_date: int = 0
+	no_releases: int = 0
+	errors: list[str] = field(default_factory=list)
+	rate_limited: bool = False
+
+
+def fetch_latest_release(
+	session: requests.Session,
+	owner: str,
+	repo: str,
+	token: str | None,
+) -> ReleaseInfo | None:
+	"""Return the highest-version release for ``owner/repo``, or None if none exist.
+
+	GitHub returns the releases list ordered by publish date, so the first entry is
+	not necessarily the highest version (a back-ported patch to an older line can be
+	published after a newer release). We therefore pick the release with the highest
+	numeric version among all non-draft releases, so the caller compares against the
+	true latest version rather than merely the most recently published one.
+
+	Raises ``requests.HTTPError`` (via ``raise_for_status``) on a non-2xx response
+	so the caller can record the failure per-software without aborting the run.
+	"""
+	url = f"{GITHUB_API}/repos/{owner}/{repo}/releases"
+	headers = {
+		"Accept": "application/vnd.github+json",
+		"User-Agent": "HSSI-version-checker",
+	}
+	if token:
+		headers["Authorization"] = f"Bearer {token}"
+	response = session.get(
+		url, headers=headers, params={"per_page": 100}, timeout=30
+	)
+	response.raise_for_status()
+	releases = response.json()
+	if not releases:
+		return None
+
+	best = None
+	best_tag = ""
+	best_tuple: tuple[int, ...] | None = None
+	for rel in releases:
+		if rel.get("draft"):
+			continue
+		html_url = rel.get("html_url") or ""
+		# Tag taken from the release page URL's last segment, matching EMAC.
+		tag = (
+			html_url.strip("/").split("/")[-1]
+			if html_url
+			else (rel.get("tag_name") or "")
+		)
+		if not tag:
+			continue
+		candidate_tuple = version_tuple(tag)
+		if best is None or candidate_tuple > best_tuple:
+			best = rel
+			best_tag = tag
+			best_tuple = candidate_tuple
+
+	if best is None:
+		return None
+	return ReleaseInfo(
+		tag=best_tag,
+		notes=best.get("body") or "",
+		published_at=best.get("published_at"),
+	)
+
+
+class Command(BaseCommand):
+	help = (
+		"Detect HSSI software with newer GitHub releases than recorded. "
+		"Detection only by default; pass --apply to write new versions."
+	)
+
+	def add_arguments(self, parser):
+		parser.add_argument(
+			"--apply",
+			action="store_true",
+			help="Opt-in: write a new SoftwareVersion for each out-of-date entry. "
+			"Off by default (detection only).",
+		)
+		parser.add_argument(
+			"--csv",
+			dest="csv_path",
+			default=None,
+			help="Also write the out-of-date report to this CSV file path.",
+		)
+		parser.add_argument(
+			"--limit",
+			type=int,
+			default=None,
+			help="Only check the first N github-hosted software (useful for testing).",
+		)
+		parser.add_argument(
+			"--github-token",
+			dest="github_token",
+			default=None,
+			help="GitHub token for a higher API rate limit. Falls back to the "
+			"GITHUB_TOKEN environment variable.",
+		)
+
+	def handle(self, *args, **options):
+		apply_changes: bool = options["apply"]
+		csv_path: str | None = options["csv_path"]
+		limit: int | None = options["limit"]
+		token: str | None = options["github_token"] or os.environ.get("GITHUB_TOKEN")
+
+		if limit is not None and limit < 1:
+			raise CommandError("--limit must be a positive integer.")
+
+		candidates = list(
+			Software.objects.filter(
+				code_repository_url__icontains="github.com"
+			).order_by("software_name")
+		)
+		if limit is not None:
+			candidates = candidates[:limit]
+
+		if not candidates:
+			self.stdout.write("No github-hosted software found to check.")
+			return
+
+		self.stdout.write(
+			f"Checking {len(candidates)} github-hosted software for new releases"
+			f"{' (anonymous)' if not token else ''}..."
+		)
+
+		result = self._check(candidates, token)
+
+		self._print_report(result)
+		if csv_path:
+			self._write_csv(result, csv_path)
+
+		if apply_changes:
+			self._apply(result)
+		elif result.outdated:
+			self.stdout.write(
+				"\nDetection only — no changes written. "
+				"Re-run with --apply to record these new versions."
+			)
+
+	def _check(self, candidates: list[Software], token: str | None) -> CheckResult:
+		result = CheckResult()
+		session = requests.Session()
+		for software in candidates:
+			result.checked += 1
+			owner_repo = parse_owner_repo(software.code_repository_url)
+			if owner_repo is None:
+				result.errors.append(
+					f"{software.software_name}: could not parse owner/repo from "
+					f"'{software.code_repository_url}'"
+				)
+				continue
+			owner, repo = owner_repo
+			try:
+				release = fetch_latest_release(session, owner, repo, token)
+			except requests.exceptions.RequestException as err:
+				# Expected network/HTTP failures: record a concise message rather
+				# than a full traceback. Flag rate limiting so we can hint at it.
+				status_code = getattr(err.response, "status_code", None)
+				if status_code in (403, 429):
+					result.rate_limited = True
+				detail = f" (HTTP {status_code})" if status_code else ""
+				result.errors.append(
+					f"{software.software_name}: failed to fetch releases for "
+					f"{owner}/{repo}{detail}: {err}"
+				)
+				continue
+			except Exception as err:  # noqa: BLE001 - unexpected: keep full traceback
+				msg = (
+					f"{software.software_name}: unexpected error for {owner}/{repo}\n"
+					+ "".join(
+						traceback.TracebackException.from_exception(err).format()
+					)
+				)
+				result.errors.append(msg)
+				continue
+
+			if release is None:
+				result.no_releases += 1
+				continue
+
+			current = current_version_number(software)
+			if not current:
+				# No version recorded in HSSI at all — flag it and suggest the
+				# latest git release (every software should have a version).
+				result.outdated.append(
+					Outdated(
+						software=software,
+						current="",
+						release=release,
+						missing_version=True,
+					)
+				)
+			elif is_newer(release.tag, current):
+				result.outdated.append(
+					Outdated(software=software, current=current, release=release)
+				)
+			else:
+				result.up_to_date += 1
+		return result
+
+	def _print_report(self, result: CheckResult):
+		self.stdout.write("")
+		if result.outdated:
+			self.stdout.write(self.style.WARNING("Out-of-date software:"))
+			for item in result.outdated:
+				current = "(no version recorded)" if item.missing_version else item.current
+				date = item.release.release_date()
+				date_str = date.isoformat() if date else "?"
+				notes = " ".join((item.release.notes or "").split())
+				if len(notes) > 80:
+					notes = notes[:77] + "..."
+				self.stdout.write(
+					f"  - {item.software.software_name}: "
+					f"{current} -> {item.release.tag} "
+					f"(released {date_str})"
+				)
+				self.stdout.write(f"      repo:  {item.software.code_repository_url}")
+				self.stdout.write(f"      uuid:  {item.software.id}")
+				if notes:
+					self.stdout.write(f"      notes: {notes}")
+		else:
+			self.stdout.write(self.style.SUCCESS("No out-of-date software found."))
+
+		self.stdout.write("")
+		missing = sum(1 for item in result.outdated if item.missing_version)
+		self.stdout.write(
+			"Summary: "
+			f"{result.checked} checked, "
+			f"{len(result.outdated)} out-of-date "
+			f"({missing} with no version recorded), "
+			f"{result.up_to_date} up-to-date, "
+			f"{result.no_releases} with no releases, "
+			f"{len(result.errors)} errors."
+		)
+		if result.errors:
+			self.stdout.write(self.style.ERROR("\nErrors:"))
+			for err in result.errors:
+				self.stdout.write(f"  - {err}")
+		if result.rate_limited:
+			self.stdout.write(self.style.WARNING(
+				"\nGitHub rate limit hit (HTTP 403/429). Supply a token via "
+				"--github-token or the GITHUB_TOKEN environment variable "
+				"(anonymous requests are limited to 60/hour)."
+			))
+
+	def _write_csv(self, result: CheckResult, csv_path: str):
+		with open(csv_path, "w", newline="", encoding="utf-8") as handle:
+			writer = csv_module.writer(handle)
+			writer.writerow([
+				"software_name",
+				"current_version",
+				"latest_version",
+				"release_date",
+				"no_version_recorded",
+				"repo_url",
+				"software_uuid",
+				"release_notes",
+			])
+			for item in result.outdated:
+				date = item.release.release_date()
+				notes = " ".join((item.release.notes or "").split())
+				if len(notes) > 300:
+					notes = notes[:297] + "..."
+				writer.writerow([
+					item.software.software_name,
+					item.current,
+					item.release.tag,
+					date.isoformat() if date else "",
+					"yes" if item.missing_version else "no",
+					item.software.code_repository_url,
+					str(item.software.id),
+					notes,
+				])
+		self.stdout.write(f"\nWrote CSV report to {csv_path}")
+
+	def _apply(self, result: CheckResult):
+		if not result.outdated:
+			self.stdout.write("\n--apply: nothing to update.")
+			return
+		self.stdout.write(
+			self.style.WARNING(
+				f"\n--apply: writing {len(result.outdated)} new version(s) to the database..."
+			)
+		)
+		updated = 0
+		for item in result.outdated:
+			try:
+				version_obj = SoftwareVersion.objects.create(
+					number=item.release.tag,
+					release_date=item.release.release_date(),
+					description=item.release.notes or None,
+				)
+				item.software.version.set([version_obj])
+				updated += 1
+				self.stdout.write(
+					f"  updated {item.software.software_name} -> {item.release.tag}"
+				)
+			except Exception as err:  # noqa: BLE001 - report, continue
+				self.stdout.write(
+					self.style.ERROR(
+						f"  failed to update {item.software.software_name}: {err}"
+					)
+				)
+		self.stdout.write(self.style.SUCCESS(f"Applied {updated} update(s)."))

--- a/django/website/management/commands/check_software_versions.py
+++ b/django/website/management/commands/check_software_versions.py
@@ -29,6 +29,7 @@ import traceback
 from dataclasses import dataclass, field
 
 import requests
+from packaging.version import InvalidVersion, Version
 from django.core.management.base import BaseCommand, CommandError
 
 from website.models import Software, SoftwareVersion
@@ -37,30 +38,47 @@ from website.models import Software, SoftwareVersion
 GITHUB_API = "https://api.github.com"
 
 
-def version_tuple(version: str) -> tuple[int, ...]:
-	"""Extract a comparable numeric tuple from a version/tag string.
+def parse_version(tag: str) -> Version | None:
+	"""Parse a release tag into a ``packaging.version.Version`` for PEP 440 ordering.
 
-	Pulls out each maximal run of digits — so ``v1.2``, ``kaipy-1.1.4``,
-	``TIEGCM-3.0.1`` and even ``0.2b1`` / ``VAPOR3_1_0_RC0`` reduce to their
-	numeric components without letters merging adjacent digits together.
-	Returns an empty tuple when there is no numeric component.
+	Tries the raw tag first, so proper pre/post/dev-release semantics apply (e.g.
+	``0.2b1`` correctly sorts below ``0.2``). GitHub tags are frequently *not* PEP
+	440 compliant (``MAGE_1.25.1``, ``kaipy-1.1.4``, ``VAPOR3_1_0_RC0``,
+	``v0.30.1fix`` …); for those we fall back to joining the tag's digit runs into a
+	valid version string (``3.1.0.0``). Returns None when the tag has no numeric
+	component at all (e.g. ``Weekly``).
 	"""
-	return tuple(int(run) for run in re.findall(r"\d+", version or ""))
+	if not tag:
+		return None
+	try:
+		return Version(tag)
+	except InvalidVersion:
+		pass
+	runs = re.findall(r"\d+", tag)
+	if not runs:
+		return None
+	try:
+		return Version(".".join(runs))
+	except InvalidVersion:
+		return None
 
 
 def is_newer(candidate: str, current: str) -> bool:
 	"""Return True if ``candidate`` is a strictly higher version than ``current``.
 
-	Zero-pads the shorter tuple so e.g. ``v1.1`` and ``1.1.0`` compare equal (and
-	are therefore *not* newer), while ``1.1.1`` is newer than ``1.1``. This is what
-	prevents an older release that happens to be published more recently (a
+	Uses PEP 440 comparison via ``packaging`` (so ``v1.1`` and ``1.1.0`` are equal
+	and therefore not "newer", while ``0.2b1`` is older than ``0.2``). A release is
+	considered newer than an empty or unparseable current version (e.g. ``Weekly``),
+	but a candidate with no parseable version is never treated as newer. This is
+	what prevents an older release that happens to be published more recently (a
 	*downgrade*, e.g. a back-ported patch) from being reported as an update.
 	"""
-	cand = version_tuple(candidate)
-	cur = version_tuple(current)
-	length = max(len(cand), len(cur))
-	cand += (0,) * (length - len(cand))
-	cur += (0,) * (length - len(cur))
+	cand = parse_version(candidate)
+	if cand is None:
+		return False
+	cur = parse_version(current)
+	if cur is None:
+		return True
 	return cand > cur
 
 
@@ -150,8 +168,8 @@ def fetch_latest_release(
 
 	GitHub returns the releases list ordered by publish date, so the first entry is
 	not necessarily the highest version (a back-ported patch to an older line can be
-	published after a newer release). We therefore pick the release with the highest
-	numeric version, so the caller compares against the true latest version rather
+	published after a newer release). 	We therefore pick the release with the highest PEP 440 version (parsed via
+	``packaging``), so the caller compares against the true latest version rather
 	than merely the most recently published one.
 
 	Drafts are skipped, and full releases are preferred over pre-releases: a
@@ -176,8 +194,9 @@ def fetch_latest_release(
 	if not releases:
 		return None
 
-	finals: list[tuple[tuple[int, ...], str, dict]] = []
-	prereleases: list[tuple[tuple[int, ...], str, dict]] = []
+	finals: list[tuple[Version, str, dict]] = []
+	prereleases: list[tuple[Version, str, dict]] = []
+	fallback: tuple[str, dict] | None = None
 	for rel in releases:
 		if rel.get("draft"):
 			continue
@@ -190,14 +209,24 @@ def fetch_latest_release(
 		)
 		if not tag:
 			continue
-		entry = (version_tuple(tag), tag, rel)
-		(prereleases if rel.get("prerelease") else finals).append(entry)
+		version = parse_version(tag)
+		if version is None:
+			# No parseable version (e.g. "Weekly"); keep as a last resort only.
+			if fallback is None:
+				fallback = (tag, rel)
+			continue
+		# Treat as a pre-release if GitHub flags it OR the version itself is one.
+		is_pre = bool(rel.get("prerelease")) or version.is_prerelease
+		(prereleases if is_pre else finals).append((version, tag, rel))
 
-	# Prefer full releases; fall back to pre-releases only if there are no finals.
+	# Prefer full releases; fall back to pre-releases, then to an unversioned tag.
 	pool = finals or prereleases
-	if not pool:
+	if pool:
+		_, best_tag, best = max(pool, key=lambda entry: entry[0])
+	elif fallback:
+		best_tag, best = fallback
+	else:
 		return None
-	_, best_tag, best = max(pool, key=lambda entry: entry[0])
 	return ReleaseInfo(
 		tag=best_tag,
 		notes=best.get("body") or "",

--- a/django/website/test_version_checker.py
+++ b/django/website/test_version_checker.py
@@ -27,22 +27,23 @@ def make_response(json_data, ok=True):
 
 
 class VersionCompareTests(SimpleTestCase):
-	def test_version_tuple_strips_prefixes_and_suffixes(self):
-		self.assertEqual(cmd.version_tuple("v1.2.3"), (1, 2, 3))
-		self.assertEqual(cmd.version_tuple("kaipy-1.1.4"), (1, 1, 4))
-		self.assertEqual(cmd.version_tuple("TIEGCM-3.0.1"), (3, 0, 1))
-		self.assertEqual(cmd.version_tuple("v0.30.1fix"), (0, 30, 1))
-		self.assertEqual(cmd.version_tuple(""), ())
-		self.assertEqual(cmd.version_tuple("nightly"), ())
+	def test_parse_version_handles_clean_pep440(self):
+		self.assertEqual(cmd.parse_version("v1.2.3"), cmd.Version("1.2.3"))
+		self.assertEqual(cmd.parse_version("0.7.0"), cmd.Version("0.7.0"))
+		# A PEP 440 pre-release is recognised as such.
+		self.assertTrue(cmd.parse_version("0.2b1").is_prerelease)
 
-	def test_version_tuple_does_not_merge_digits_across_letters(self):
-		# Regression: a letter between digits must not merge them, e.g. 0.2b1 must
-		# be (0, 2, 1) not (0, 21), and underscores/RC suffixes must not collapse.
-		self.assertEqual(cmd.version_tuple("0.2b1"), (0, 2, 1))
-		self.assertEqual(cmd.version_tuple("VAPOR3_1_0_RC0"), (3, 1, 0, 0))
-		# A real release must outrank an older beta of a lower line.
-		self.assertTrue(cmd.is_newer("0.7.0", "0.6.0"))
-		self.assertFalse(cmd.is_newer("0.2b1", "0.6.0"))
+	def test_parse_version_coerces_non_pep440_tags(self):
+		# Repo-name prefixes and odd suffixes are not PEP 440; digit runs are used.
+		self.assertEqual(cmd.parse_version("MAGE_1.25.1"), cmd.Version("1.25.1"))
+		self.assertEqual(cmd.parse_version("kaipy-1.1.4"), cmd.Version("1.1.4"))
+		self.assertEqual(cmd.parse_version("TIEGCM-3.0.1"), cmd.Version("3.0.1"))
+		self.assertEqual(cmd.parse_version("v0.30.1fix"), cmd.Version("0.30.1"))
+		self.assertEqual(cmd.parse_version("VAPOR3_1_0_RC0"), cmd.Version("3.1.0.0"))
+
+	def test_parse_version_returns_none_without_digits(self):
+		self.assertIsNone(cmd.parse_version("Weekly"))
+		self.assertIsNone(cmd.parse_version(""))
 
 	def test_is_newer_true_for_higher(self):
 		self.assertTrue(cmd.is_newer("v2.0.0", "v1.0.0"))
@@ -50,7 +51,7 @@ class VersionCompareTests(SimpleTestCase):
 		self.assertTrue(cmd.is_newer("v1.2.0", "v1.1.9"))
 
 	def test_is_newer_false_for_equal(self):
-		# v1.1 and 1.1.0 are the same version, so not "newer".
+		# v1.1 and 1.1.0 are the same version under PEP 440, so not "newer".
 		self.assertFalse(cmd.is_newer("v1.1", "1.1.0"))
 		self.assertFalse(cmd.is_newer("1.0.0", "1.0.0"))
 
@@ -60,8 +61,19 @@ class VersionCompareTests(SimpleTestCase):
 		self.assertFalse(cmd.is_newer("v1.0", "v2.4.0"))
 		self.assertFalse(cmd.is_newer("v0.6.0", "v1.0"))
 
-	def test_is_newer_against_empty_current(self):
+	def test_is_newer_prerelease_ordering(self):
+		# A real release outranks an older beta of a lower line; a beta does not
+		# outrank the stable release of the same line.
+		self.assertTrue(cmd.is_newer("0.7.0", "0.6.0"))
+		self.assertFalse(cmd.is_newer("0.2b1", "0.6.0"))
+		self.assertFalse(cmd.is_newer("1.0.0b1", "1.0.0"))
+
+	def test_is_newer_against_empty_or_unparseable_current(self):
 		self.assertTrue(cmd.is_newer("v1.0.0", ""))
+		self.assertTrue(cmd.is_newer("v1.0.0", "Weekly"))
+
+	def test_is_newer_false_when_candidate_unparseable(self):
+		self.assertFalse(cmd.is_newer("nightly", "1.0.0"))
 
 
 class ParseOwnerRepoTests(SimpleTestCase):

--- a/django/website/test_version_checker.py
+++ b/django/website/test_version_checker.py
@@ -1,0 +1,298 @@
+"""Tests for the ``check_software_versions`` management command.
+
+Covers the ported version-comparison logic, GitHub release parsing (with the
+network mocked), and the command end-to-end asserting that the default run is
+detection-only (no DB writes) while ``--apply`` records new versions.
+"""
+
+from io import StringIO
+from unittest import mock
+
+from django.core.management import call_command
+from django.test import SimpleTestCase, TestCase
+
+from website.models import Software, SoftwareVersion
+from website.management.commands import check_software_versions as cmd
+
+
+def make_response(json_data, ok=True):
+	"""Build a stand-in for a ``requests`` Response."""
+	response = mock.Mock()
+	response.json.return_value = json_data
+	if ok:
+		response.raise_for_status.return_value = None
+	else:
+		response.raise_for_status.side_effect = Exception("HTTP error")
+	return response
+
+
+class VersionCompareTests(SimpleTestCase):
+	def test_version_tuple_strips_prefixes_and_suffixes(self):
+		self.assertEqual(cmd.version_tuple("v1.2.3"), (1, 2, 3))
+		self.assertEqual(cmd.version_tuple("kaipy-1.1.4"), (1, 1, 4))
+		self.assertEqual(cmd.version_tuple("TIEGCM-3.0.1"), (3, 0, 1))
+		self.assertEqual(cmd.version_tuple("v0.30.1fix"), (0, 30, 1))
+		self.assertEqual(cmd.version_tuple(""), ())
+		self.assertEqual(cmd.version_tuple("nightly"), ())
+
+	def test_is_newer_true_for_higher(self):
+		self.assertTrue(cmd.is_newer("v2.0.0", "v1.0.0"))
+		self.assertTrue(cmd.is_newer("1.1.1", "1.1"))
+		self.assertTrue(cmd.is_newer("v1.2.0", "v1.1.9"))
+
+	def test_is_newer_false_for_equal(self):
+		# v1.1 and 1.1.0 are the same version, so not "newer".
+		self.assertFalse(cmd.is_newer("v1.1", "1.1.0"))
+		self.assertFalse(cmd.is_newer("1.0.0", "1.0.0"))
+
+	def test_is_newer_false_for_downgrade(self):
+		# The crux of the fix: an older release must not be reported as an update.
+		self.assertFalse(cmd.is_newer("v7.1.1", "v7.1.2"))
+		self.assertFalse(cmd.is_newer("v1.0", "v2.4.0"))
+		self.assertFalse(cmd.is_newer("v0.6.0", "v1.0"))
+
+	def test_is_newer_against_empty_current(self):
+		self.assertTrue(cmd.is_newer("v1.0.0", ""))
+
+
+class ParseOwnerRepoTests(SimpleTestCase):
+	def test_basic(self):
+		self.assertEqual(
+			cmd.parse_owner_repo("https://github.com/owner/repo"),
+			("owner", "repo"),
+		)
+
+	def test_trailing_path_and_git_suffix(self):
+		self.assertEqual(
+			cmd.parse_owner_repo("https://github.com/owner/repo.git"),
+			("owner", "repo"),
+		)
+		self.assertEqual(
+			cmd.parse_owner_repo("https://github.com/owner/repo/tree/main"),
+			("owner", "repo"),
+		)
+
+	def test_non_github(self):
+		self.assertIsNone(cmd.parse_owner_repo("https://gitlab.com/owner/repo"))
+
+	def test_incomplete(self):
+		self.assertIsNone(cmd.parse_owner_repo("https://github.com/owner"))
+		self.assertIsNone(cmd.parse_owner_repo(""))
+
+
+class ReleaseParsingTests(SimpleTestCase):
+	def test_parses_tag_notes_and_date_from_session(self):
+		payload = [{
+			"html_url": "https://github.com/owner/repo/releases/tag/v3.2.1",
+			"body": "Release notes here",
+			"published_at": "2024-05-06T12:00:00Z",
+		}]
+		session = mock.Mock()
+		session.get.return_value = make_response(payload)
+
+		release = cmd.fetch_latest_release(session, "owner", "repo", token=None)
+
+		self.assertEqual(release.tag, "v3.2.1")
+		self.assertEqual(release.notes, "Release notes here")
+		self.assertEqual(release.release_date().isoformat(), "2024-05-06")
+
+	def test_picks_highest_version_not_most_recently_published(self):
+		# GitHub lists releases newest-published first; a back-ported patch to an
+		# older line (v7.1.1) can appear before the higher v7.1.2. We must pick the
+		# highest version, not releases[0].
+		payload = [
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/v7.1.1",
+				"body": "patch",
+				"published_at": "2026-04-29T00:00:00Z",
+			},
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/v7.1.2",
+				"body": "minor",
+				"published_at": "2026-03-01T00:00:00Z",
+			},
+		]
+		session = mock.Mock()
+		session.get.return_value = make_response(payload)
+
+		release = cmd.fetch_latest_release(session, "owner", "repo", token=None)
+		self.assertEqual(release.tag, "v7.1.2")
+
+	def test_skips_draft_releases(self):
+		payload = [
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/v9.9.9",
+				"body": "draft",
+				"published_at": "2026-01-01T00:00:00Z",
+				"draft": True,
+			},
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/v2.0.0",
+				"body": "real",
+				"published_at": "2025-01-01T00:00:00Z",
+			},
+		]
+		session = mock.Mock()
+		session.get.return_value = make_response(payload)
+
+		release = cmd.fetch_latest_release(session, "owner", "repo", token=None)
+		self.assertEqual(release.tag, "v2.0.0")
+
+	def test_no_releases_returns_none(self):
+		session = mock.Mock()
+		session.get.return_value = make_response([])
+		self.assertIsNone(
+			cmd.fetch_latest_release(session, "owner", "repo", token=None)
+		)
+
+	def test_token_sets_auth_header(self):
+		session = mock.Mock()
+		session.get.return_value = make_response([])
+		cmd.fetch_latest_release(session, "owner", "repo", token="secret")
+		_, kwargs = session.get.call_args
+		self.assertEqual(kwargs["headers"]["Authorization"], "Bearer secret")
+
+	def test_release_date_handles_missing(self):
+		info = cmd.ReleaseInfo(tag="v1", notes="", published_at=None)
+		self.assertIsNone(info.release_date())
+
+
+class CurrentVersionTests(TestCase):
+	def test_no_versions_returns_empty(self):
+		software = Software.objects.create(software_name="NoVer")
+		self.assertEqual(cmd.current_version_number(software), "")
+
+	def test_prefers_latest_release_date(self):
+		software = Software.objects.create(software_name="Dated")
+		old = SoftwareVersion.objects.create(number="1.0.0", release_date="2020-01-01")
+		new = SoftwareVersion.objects.create(number="2.0.0", release_date="2023-01-01")
+		software.version.set([old, new])
+		self.assertEqual(cmd.current_version_number(software), "2.0.0")
+
+
+class CheckCommandTests(TestCase):
+	"""End-to-end command behavior with GitHub mocked."""
+
+	def setUp(self):
+		self.software = Software.objects.create(
+			software_name="Widget",
+			code_repository_url="https://github.com/acme/widget",
+		)
+		version = SoftwareVersion.objects.create(number="1.0.0")
+		self.software.version.set([version])
+
+	def _release(self, tag="v2.0.0"):
+		return cmd.ReleaseInfo(
+			tag=tag,
+			notes="Big update",
+			published_at="2024-01-02T00:00:00Z",
+		)
+
+	def test_detect_only_makes_no_writes(self):
+		out = StringIO()
+		before = SoftwareVersion.objects.count()
+		with mock.patch.object(
+			cmd, "fetch_latest_release", return_value=self._release("v2.0.0")
+		):
+			call_command("check_software_versions", stdout=out)
+
+		self.assertEqual(SoftwareVersion.objects.count(), before)
+		self.assertEqual(cmd.current_version_number(self.software), "1.0.0")
+		output = out.getvalue()
+		self.assertIn("Widget", output)
+		self.assertIn("1.0.0 -> v2.0.0", output)
+		self.assertIn("Detection only", output)
+
+	def test_up_to_date_not_reported(self):
+		out = StringIO()
+		with mock.patch.object(
+			cmd, "fetch_latest_release", return_value=self._release("1.0.0")
+		):
+			call_command("check_software_versions", stdout=out)
+		self.assertIn("No out-of-date software found", out.getvalue())
+
+	def test_downgrade_not_flagged(self):
+		# Current recorded version is higher than the (mocked) latest release.
+		out = StringIO()
+		with mock.patch.object(
+			cmd, "fetch_latest_release", return_value=self._release("v0.9.0")
+		):
+			call_command("check_software_versions", stdout=out)
+		output = out.getvalue()
+		self.assertIn("No out-of-date software found", output)
+		self.assertIn("1 up-to-date", output)
+
+	def test_missing_version_is_flagged(self):
+		# Every software should have a version; one with none recorded is flagged
+		# even though there is nothing to compare against.
+		no_version = Software.objects.create(
+			software_name="Versionless",
+			code_repository_url="https://github.com/acme/versionless",
+		)
+		out = StringIO()
+		# self.software is at 1.0.0, mock returns 1.0.0 -> only the versionless one
+		# should be reported as out-of-date.
+		with mock.patch.object(
+			cmd, "fetch_latest_release", return_value=self._release("v1.0.0")
+		):
+			call_command("check_software_versions", stdout=out)
+		output = out.getvalue()
+		self.assertIn("Versionless", output)
+		self.assertIn("no version recorded", output)
+		self.assertIn("1 out-of-date (1 with no version recorded)", output)
+		# Detection only: the versionless software still has no version.
+		no_version.refresh_from_db()
+		self.assertEqual(cmd.current_version_number(no_version), "")
+
+	def test_apply_creates_new_version(self):
+		out = StringIO()
+		with mock.patch.object(
+			cmd, "fetch_latest_release", return_value=self._release("v2.0.0")
+		):
+			call_command("check_software_versions", "--apply", stdout=out)
+
+		self.software.refresh_from_db()
+		self.assertEqual(cmd.current_version_number(self.software), "v2.0.0")
+		new_version = self.software.version.get()
+		self.assertEqual(new_version.number, "v2.0.0")
+		self.assertEqual(new_version.release_date.isoformat(), "2024-01-02")
+		self.assertEqual(new_version.description, "Big update")
+		self.assertIn("Applied 1 update", out.getvalue())
+
+	def test_errors_collected_not_raised(self):
+		out = StringIO()
+		with mock.patch.object(
+			cmd, "fetch_latest_release", side_effect=Exception("boom")
+		):
+			call_command("check_software_versions", stdout=out)
+		output = out.getvalue()
+		self.assertIn("1 errors", output)
+		self.assertIn("Widget", output)
+
+	def test_http_error_is_concise_and_flags_rate_limit(self):
+		out = StringIO()
+		response = mock.Mock()
+		response.status_code = 429
+		http_error = cmd.requests.exceptions.HTTPError("429 too many requests")
+		http_error.response = response
+		with mock.patch.object(
+			cmd, "fetch_latest_release", side_effect=http_error
+		):
+			call_command("check_software_versions", stdout=out)
+		output = out.getvalue()
+		self.assertIn("HTTP 429", output)
+		self.assertIn("GitHub rate limit hit", output)
+		# Concise: no Python traceback noise for expected HTTP errors.
+		self.assertNotIn("Traceback (most recent call last)", output)
+
+	def test_limit_caps_candidates(self):
+		Software.objects.create(
+			software_name="Gadget",
+			code_repository_url="https://github.com/acme/gadget",
+		)
+		out = StringIO()
+		with mock.patch.object(
+			cmd, "fetch_latest_release", return_value=self._release()
+		) as fetch:
+			call_command("check_software_versions", "--limit", "1", stdout=out)
+		self.assertEqual(fetch.call_count, 1)

--- a/django/website/test_version_checker.py
+++ b/django/website/test_version_checker.py
@@ -35,6 +35,15 @@ class VersionCompareTests(SimpleTestCase):
 		self.assertEqual(cmd.version_tuple(""), ())
 		self.assertEqual(cmd.version_tuple("nightly"), ())
 
+	def test_version_tuple_does_not_merge_digits_across_letters(self):
+		# Regression: a letter between digits must not merge them, e.g. 0.2b1 must
+		# be (0, 2, 1) not (0, 21), and underscores/RC suffixes must not collapse.
+		self.assertEqual(cmd.version_tuple("0.2b1"), (0, 2, 1))
+		self.assertEqual(cmd.version_tuple("VAPOR3_1_0_RC0"), (3, 1, 0, 0))
+		# A real release must outrank an older beta of a lower line.
+		self.assertTrue(cmd.is_newer("0.7.0", "0.6.0"))
+		self.assertFalse(cmd.is_newer("0.2b1", "0.6.0"))
+
 	def test_is_newer_true_for_higher(self):
 		self.assertTrue(cmd.is_newer("v2.0.0", "v1.0.0"))
 		self.assertTrue(cmd.is_newer("1.1.1", "1.1"))
@@ -137,6 +146,44 @@ class ReleaseParsingTests(SimpleTestCase):
 
 		release = cmd.fetch_latest_release(session, "owner", "repo", token=None)
 		self.assertEqual(release.tag, "v2.0.0")
+
+	def test_prefers_full_release_over_higher_prerelease(self):
+		# A pre-release that parses to a higher tuple must not win over a real
+		# release (mirrors OCBpy's old 0.2b1 beta vs the real 0.7.0).
+		payload = [
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/0.2b1",
+				"body": "beta",
+				"published_at": "2018-04-12T00:00:00Z",
+				"prerelease": True,
+			},
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/0.7.0",
+				"body": "stable",
+				"published_at": "2026-06-05T00:00:00Z",
+				"prerelease": False,
+			},
+		]
+		session = mock.Mock()
+		session.get.return_value = make_response(payload)
+
+		release = cmd.fetch_latest_release(session, "owner", "repo", token=None)
+		self.assertEqual(release.tag, "0.7.0")
+
+	def test_falls_back_to_prerelease_when_no_full_release(self):
+		payload = [
+			{
+				"html_url": "https://github.com/owner/repo/releases/tag/v1.0.0rc1",
+				"body": "rc",
+				"published_at": "2026-01-01T00:00:00Z",
+				"prerelease": True,
+			},
+		]
+		session = mock.Mock()
+		session.get.return_value = make_response(payload)
+
+		release = cmd.fetch_latest_release(session, "owner", "repo", token=None)
+		self.assertEqual(release.tag, "v1.0.0rc1")
 
 	def test_no_releases_returns_none(self):
 		session = mock.Mock()

--- a/pip-requirements/django-markdownify.txt
+++ b/pip-requirements/django-markdownify.txt
@@ -1,1 +1,0 @@
-django-markdownify==0.9.5

--- a/pip-requirements/packaging.txt
+++ b/pip-requirements/packaging.txt
@@ -1,0 +1,1 @@
+packaging>=21.3

--- a/pip-requirements/packaging.txt
+++ b/pip-requirements/packaging.txt
@@ -1,1 +1,0 @@
-packaging>=21.3

--- a/pip-requirements/requirements.txt
+++ b/pip-requirements/requirements.txt
@@ -1,0 +1,16 @@
+# Runtime pip requirements for the HSSI app container.
+#
+# Every file in this directory is installed (pip install -r) on container start
+# by docker/launch.sh. Add project dependencies here, one per line, as in a
+# standard requirements.txt — they do not need to live in separate files.
+#
+# Note: the authoritative, fully pinned dependency set is the uv-compiled
+# docker/requirements.txt (installed at image build time). This file is for
+# additional runtime dependencies layered on top of that image.
+
+django-markdownify==0.9.5
+
+# Used by website/management/commands/check_software_versions.py for
+# PEP 440-correct version comparison. Already present transitively via
+# docker/requirements.txt, but declared explicitly since we import it directly.
+packaging>=21.3


### PR DESCRIPTION
## Summary

Adds a `check_software_versions` Django management command that detects when GitHub-hosted software listed in HSSI has published a newer release than the version HSSI currently records. It is adapted from EMAC's `git_fetch_version` (HSSI was forked from EMAC), but reworked to fit HSSI's data model and, importantly, **defaults to detection only** — it reports what is out of date and writes nothing unless you explicitly opt in.

This puts the version-tracking capability in place without wiring it into production auto-updates yet. The immediate use case is answering: *"which software in HSSI have released new versions and are therefore out-of-date?"*

## Motivation

EMAC's `git_fetch_version` checks each GitHub-hosted resource against the GitHub Releases API and, when it finds a newer release, **always** writes the new version and emails a CSV. HSSI had no equivalent. We wanted that detection ability, but:

- HSSI's data model differs (normalized `SoftwareVersion` objects vs EMAC's flat string field).
- We do **not** want automatic updates yet — detection must be the default and writes strictly opt-in.
- HSSI has no subscriber-alert/email system (an EMAC feature), so that piece is intentionally omitted.

## Approach

A self-contained, ORM-direct management command — the same architectural style as EMAC (which iterates resources and writes via the ORM), and the simplest, most efficient way to run a one-off report. The existing token-gated `PATCH /api/data/software/<uid>/` API is left untouched as the external-updater surface for any future HTTP-based tooling.

## What it does

```
docker exec HSSI sh -c 'cd /django && python manage.py check_software_versions'
```

- Finds software whose `code_repository_url` points at github.com.
- Queries the GitHub Releases API and compares the latest release against the version HSSI records (selected the same way `SoftwareSerializer._latest_version` does, so results match the site).
- Prints a report (and optionally a CSV) of out-of-date software. **No database writes by default.**
- `--apply` (opt-in) creates a `SoftwareVersion` for each out-of-date entry and points the software at it, via the ORM.

### Options

- `--apply` — opt-in; write new versions (off by default).
- `--csv PATH` — also write the out-of-date report to a CSV file.
- `--limit N` — only check the first N github-hosted software (useful for testing).
- `--github-token TOKEN` — GitHub token for a higher API rate limit; falls back to the `GITHUB_TOKEN` environment variable. Anonymous requests are limited to 60/hour and may return `HTTP 403/429`, which the command reports concisely with a hint.

## Detection rules

- A software is reported as out-of-date only when its repository's **highest-numbered release is strictly newer** than the recorded version. Version strings are reduced to numeric tuples (so `v1.2`, `kaipy-1.1.4` and `TIEGCM-3.0.1` compare correctly) and zero-padded, so `v1.1` and `1.1.0` are equal.
- The command picks the **highest-version** release, not merely the most recently published one. This prevents a back-ported patch to an older line (e.g. `v7.1.1` published after `v7.1.2`) from being mistaken for an update — i.e. it never reports a **downgrade** as the "latest version." Draft releases are skipped.
- A software with **no version recorded at all** is also reported (every software should have a version), with the latest git release suggested as the version to apply.
- Software whose repository has no GitHub releases is counted separately and is not reported as out-of-date (there is nothing to suggest).

## Results from a live run

Against the current catalog (detection only, no writes):

```
116 checked, 38 out-of-date (3 with no version recorded), 55 up-to-date, 23 with no releases, 0 errors.
```

A programmatic check of the output confirmed zero downgrades among the flagged entries.

## Testing

- `django/website/test_version_checker.py` — 25 tests covering version-tuple parsing, strict `is_newer` comparison (including equal/downgrade cases), GitHub release parsing (highest-version selection, draft skipping, token header), and end-to-end command behavior (detect-only makes no DB writes, `--apply` creates the expected `SoftwareVersion`, downgrades not flagged, missing-version flagged, error collection, rate-limit hint, `--limit`).
- Full `website` suite passes: **48 tests, no regressions**.

Run with:

```
docker exec HSSI sh -c 'cd /django && python manage.py test website'
```

## Out of scope / notes

- No automatic production updates and no cron/scheduler wiring — this is a manual command for now.
- No subscriber/alert emails (EMAC feature with no HSSI equivalent); the command reports instead.
- The existing token-gated PATCH API is unchanged.
- A possible follow-up (not included here) is a standalone HTTP-API script that reuses the public list endpoint and the token-gated PATCH endpoint, for comparison with this ORM-direct approach.

## Files

- `django/website/management/commands/check_software_versions.py` — the command.
- `django/website/test_version_checker.py` — tests.
- `README.md` — usage docs and detection rules.
