### PR TITLE
JsonLD changes, Search API Changes, Bugfix

### DIFF
--- a/django/static/css/filter_menu.css
+++ b/django/static/css/filter_menu.css
@@ -203,7 +203,8 @@
 /* Field search help accordion */
 .field-search-help {
 	font-family: Arial, Helvetica, sans-serif;
-	font-size: 12px;
+	font-size: 16px;
+	font-weight: bold;
 	background-color: #ececec;
 	border-top: 1px solid #d0d0d0;
 	margin: 0.6rem;
@@ -231,6 +232,7 @@
 }
 
 .field-search-body {
+	color: #555;
 	padding: 6px 10px 10px;
 	border-top: 1px solid #d0d0d0;
 }

--- a/django/website/models/serializers/software.py
+++ b/django/website/models/serializers/software.py
@@ -117,8 +117,8 @@ class SoftwareSerializer(HssiSerializer):
 			data["propertyID"] = property_id
 		if value:
 			data["value"] = value
-		if name:
-			data["name"] = name
+		#if name:
+		#	data["name"] = name
 		return data
 
 	def _organization_jsonld(self, org: Organization | None) -> dict[str, Any] | None:
@@ -265,14 +265,21 @@ class SoftwareSerializer(HssiSerializer):
 		data: dict[str, Any] = {
 			"@type": "DataDownload",
 			"contentUrl": content_url,
-			"dateModified": "2025-03-05T12:34:56",
-			"encodingFormat": "application/json",
-			"name": "HSSI metadata describing the software",
-			"description": "HSSI metadata describing the software",
+			"dateModified": None,
+			"description": "HSSI metadata describing the indicated software",
+			"encodingFormat": "application/ld+json",
+			"license": None,
+			"name": "HSSI metadata",
 		}
-		if version.release_date:
-			data["dateModified"] = version.release_date.isoformat()
-		return data
+		if instance.license:
+			data["license"] = instance.license.url
+		if instance.submission_info:
+			data["dateModified"] = (
+				instance.submission_info.filter(submission_date__isnull=False)
+					.latest("submission_date")
+					.submission_date
+			)
+		return { key: value for key, value in data.items() if value }
 
 	def to_representation_jsonld(self, instance: Software) -> dict[str, Any]:
 
@@ -336,13 +343,12 @@ class SoftwareSerializer(HssiSerializer):
 
 		spatial_coverage = [
 			{
-				"@type": "Place",
+				"@type": ["Place", "DefinedTerm"],
 				"name": item.name,
-				"keywords": self._defined_term(
-					item.name,
-					"RelatedRegion",
-					URL_TERMSET_PHENOMENA,
-				),
+				"description": "RelatedRegion",
+				"inDefinedTermSet": 
+					"https://github.com/rmcgranaghan/" + 
+					"Helio-KNOW/blob/main/data-models/hk_region.ttl",
 			}
 			for item in instance.related_region.all()
 		]
@@ -364,6 +370,8 @@ class SoftwareSerializer(HssiSerializer):
 			for funder in instance.funder.all():
 				funding_item["@type"] = "MonetaryGrant"
 				funding_item["funder"] = self._organization_jsonld(funder)
+		if not funding_item.get("name"):
+			funding_item = None
 
 		json_id = instance.persistent_identifier
 		if not json_id:
@@ -432,7 +440,13 @@ class SoftwareSerializer(HssiSerializer):
 			"softwareVersion": latest_version.number if latest_version else None,
 			"spatialCoverage": spatial_coverage or None,
 			"subjectOf": self._subject_of(instance),
+			"url": json_id,
 			"version": latest_version.number if latest_version else None,
+			"offers": {
+  				"@type": "Offer",
+  				"price": 0,
+        		"priceCurrency": "USD",
+	      	},
 		}
 
 		return {

--- a/django/website/models/serializers/software.py
+++ b/django/website/models/serializers/software.py
@@ -381,16 +381,17 @@ class SoftwareSerializer(HssiSerializer):
 			if not json_id: json_id = instance.code_repository_url
 
 		json_pub = self._organization_jsonld(instance.publisher)
-		json_pub_ident: str = json_pub.get("@id")
-		if json_pub_ident:
-			json_pub_ident = json_pub_ident.lower()
-			if not (
-					"doi.org" in json_pub_ident or 
-					"ror.org" in json_pub_ident or 
-					"orcid.org" in json_pub_ident
-				):
-				json_pub = None
-		else: json_pub = None
+		if json_pub:
+			json_pub_ident: str = json_pub.get("@id")
+			if json_pub_ident:
+				json_pub_ident = json_pub_ident.lower()
+				if not (
+						"doi.org" in json_pub_ident or 
+						"ror.org" in json_pub_ident or 
+						"orcid.org" in json_pub_ident
+					):
+					json_pub = None
+			else: json_pub = None
 
 		data: dict[str, Any] = {
 			"@id": json_id,

--- a/django/website/models/serializers/software.py
+++ b/django/website/models/serializers/software.py
@@ -185,7 +185,8 @@ class SoftwareSerializer(HssiSerializer):
 		name: str, 
 		description: str | None = None, 
 		in_set: str | None = None
-	) -> dict[str, Any]:
+	) -> dict[str, Any] | str:
+		if not description and not in_set: return name
 		data: dict[str, Any] = {
 			"@type": "DefinedTerm",
 			"name": name,
@@ -305,7 +306,7 @@ class SoftwareSerializer(HssiSerializer):
 			for item in instance.related_phenomena.all()
 		]
 		keywords += [
-			self._defined_term(item.name, "softwareFunctionality", URL_TERMSET_FUNCTIONCATEGORY)
+			self._defined_term(item.get_full_name(), "softwareFunctionality", URL_TERMSET_FUNCTIONCATEGORY)
 			for item in instance.software_functionality.all()
 		]
 		keywords += [self._defined_term(item.name) for item in instance.keywords.all()]
@@ -379,6 +380,18 @@ class SoftwareSerializer(HssiSerializer):
 				json_id = latest_version.version_pid.strip()
 			if not json_id: json_id = instance.code_repository_url
 
+		json_pub = self._organization_jsonld(instance.publisher)
+		json_pub_ident: str = json_pub.get("@id")
+		if json_pub_ident:
+			json_pub_ident = json_pub_ident.lower()
+			if not (
+					"doi.org" in json_pub_ident or 
+					"ror.org" in json_pub_ident or 
+					"orcid.org" in json_pub_ident
+				):
+				json_pub = None
+		else: json_pub = None
+
 		data: dict[str, Any] = {
 			"@id": json_id,
 			"@type": ["SoftwareSourceCode", "SoftwareApplication"],
@@ -436,7 +449,7 @@ class SoftwareSerializer(HssiSerializer):
 			"operatingSystem": self._maybe_single(operating_systems),
 			"processorRequirements": processor_requirements or None,
 			"programmingLanguage": self._maybe_single(programming_languages),
-			"publisher": self._organization_jsonld(instance.publisher),
+			"publisher": json_pub,
 			"softwareVersion": latest_version.number if latest_version else None,
 			"spatialCoverage": spatial_coverage or None,
 			"subjectOf": self._subject_of(instance),

--- a/django/website/templates/website/categorized_resources.html
+++ b/django/website/templates/website/categorized_resources.html
@@ -91,7 +91,7 @@
 							</span>
 						</div>
 						<div class="field-search-group">
-							<span class="field-search-group-label">People &amp; Orgs</span>
+							<span class="field-search-group-label">Affiliation</span>
 							<span class="field-search-codes">
 								<code>author</code>
 								<code>publisher</code>

--- a/django/website/views/search.py
+++ b/django/website/views/search.py
@@ -6,6 +6,8 @@ from django.http import HttpRequest, JsonResponse
 
 from ..models import Software, VerifiedSoftware
 from ..models.people import Person
+from ..models.serializers.software import SoftwareSerializer
+from ..models.serializers.util import SerialView
 
 
 # ---------------------------------------------------------------------------
@@ -104,6 +106,23 @@ def build_field_query(query: str, tokens: list[str], fields: list[str]) -> Q:
     return q
 
 
+def serialize_results(result_ids: list[str], mode: str, request: HttpRequest) -> JsonResponse:
+    if mode == "id":
+        return JsonResponse({"results": result_ids})
+    software_map = {
+        str(s.id): s
+        for s in Software.objects.filter(id__in=result_ids)
+    }
+    jsonld_list = []
+    for uid in result_ids:
+        s = software_map.get(uid)
+        if s:
+            serializer = SoftwareSerializer(s, context={"request": request})
+            serializer._view = SerialView.JSONLD
+            jsonld_list.append(serializer.data)
+    return JsonResponse({"results": jsonld_list})
+
+
 def search_visible_software(request: HttpRequest) -> JsonResponse:
     """
     Search visible software by query terms and return ordered result IDs.
@@ -114,6 +133,9 @@ def search_visible_software(request: HttpRequest) -> JsonResponse:
     """
     start_time = time.monotonic()
     raw_query = (request.GET.get("q") or "").strip()
+    mode = (request.GET.get("mode") or "jsonld").lower()
+    if mode not in ("id", "jsonld"):
+        return JsonResponse({"error": f"Invalid mode '{mode}'. Must be 'id' or 'jsonld'."}, status=400)
     if not raw_query:
         return JsonResponse({"results": []})
 
@@ -166,7 +188,7 @@ def search_visible_software(request: HttpRequest) -> JsonResponse:
         result_ids = [str(uid) for uid in base_qs.values_list("id", flat=True)]
         total_elapsed = time.monotonic() - start_time
         print(f"[search] field-only total_results={len(result_ids)} elapsed={total_elapsed:.3f}s")
-        return JsonResponse({"results": result_ids})
+        return serialize_results(result_ids, mode, request)
 
     tokens = [token for token in re.split(r"\s+", query) if token]
     print(f"[search] query='{query}' tokens={tokens}")
@@ -263,4 +285,4 @@ def search_visible_software(request: HttpRequest) -> JsonResponse:
 
     total_elapsed = time.monotonic() - start_time
     print(f"[search] total_results={len(result_ids)} elapsed={total_elapsed:.3f}s")
-    return JsonResponse({"results": result_ids})
+    return serialize_results(result_ids, mode, request)

--- a/frontend/filters/search.ts
+++ b/frontend/filters/search.ts
@@ -13,6 +13,7 @@ import {
 export const idSearchbar = "searchbar";
 export const idSearchButton = "searchbar-btn";
 export const searchParamQuery = "q";
+export const searchModeQuery = "mode";
 const searchApiUrl = "/api/search/";
 
 /** 
@@ -157,6 +158,7 @@ export async function searchForQuery(
 async function getRelevantQueryIds(query: string): Promise<string[]> {
 	const url = new URL(searchApiUrl, window.location.origin);
 	url.searchParams.set(searchParamQuery, query);
+	url.searchParams.set(searchModeQuery, "id");
 	const response = await fetchTimeout(url.toString());
 	if (!response.ok) {
 		throw new Error(`Search request failed with ${response.status}`);


### PR DESCRIPTION
This PR Implements several changes:

- JsonLD format has changed, reworking several fields as outlined in [this document](https://docs.google.com/document/d/1zVIZ3EuPjM0yS5L97p7eLqvNhawc1-INF2NdNdxkQyc/edit?tab=t.0)
- Search API now returns a serialized JsonLD for each result instead of just the uuid by default
- Search API has a new query paramater 'mode' which allows the user to specify that they want the query to return just software UUIDs instead of serialized JsonLD with `mode=id`
- Fixed a bug where some software fields being left blank caused a crash during JsonLD serialization

Code changes are not too major, let me know if you have any questions or concerns. I've tested the serialization fix against every software entry in the DB, so there should be no more crashes.