### PR TITLE
Implement Organization Authors

### DIFF
--- a/django/website/forms/names.py
+++ b/django/website/forms/names.py
@@ -24,6 +24,7 @@ TYPE_AUTOFILLSOMEF = "AutofillSomefWidget"
 TYPE_AUTOFILLDATACITE = "AutofillDataciteWidget"
 TYPE_ROR = "RorWidget"
 TYPE_ORCID = "OrcidWidget"
+TYPE_AUTHORIDENTIFIER = "AuthorIdentifierWidget"
 TYPE_DATACITEDOI = "DataciteDoiWidget"
 TYPE_MODELBOX = "ModelBox"
 

--- a/django/website/forms/submission_data.py
+++ b/django/website/forms/submission_data.py
@@ -192,7 +192,7 @@ SUBMISSION_FORM_AUTHOR: ModelStructure = ModelStructure.define(
 	ModelSubfield.define(
 		name=FIELD_AUTHORIDENTIFIER,
 		row_name=ROW_PERSON_IDENTIFIER,
-		type=TYPE_ORCID,
+		type=TYPE_AUTHORIDENTIFIER,
 		requirement=RequirementLevel.RECOMMENDED,
 		properties={
 			PROP_LABEL: "Author Identifier",

--- a/django/website/models/serializers/software.py
+++ b/django/website/models/serializers/software.py
@@ -135,7 +135,25 @@ class SoftwareSerializer(HssiSerializer):
 			data["url"] = org.website
 		return data
 
+	def _person_is_org(self, person: Person) -> bool:
+		return bool(person.identifier and "ror.org" in person.identifier)
+
 	def _person_jsonld(self, person: Person) -> dict[str, Any]:
+		affiliations = self._as_list(
+			self._organization_jsonld(org) for org in person.affiliation.all()
+		)
+		if self._person_is_org(person):
+			data: dict[str, Any] = {
+				"@type": "Organization",
+				"name": person.fullName,
+			}
+			if person.identifier:
+				data["@id"] = person.identifier
+				data["identifier"] = self._property_value(person.identifier)
+			if affiliations:
+				data["parentOrganization"] = self._maybe_single(affiliations)
+			return data
+
 		data: dict[str, Any] = {
 			"@type": "Person",
 			"givenName": person.given_name,
@@ -144,9 +162,6 @@ class SoftwareSerializer(HssiSerializer):
 		if person.identifier:
 			data["@id"] = person.identifier
 			data["identifier"] = self._property_value(person.identifier)
-		affiliations = self._as_list(
-			self._organization_jsonld(org) for org in person.affiliation.all()
-		)
 		if affiliations:
 			data["affiliation"] = self._maybe_single(affiliations)
 		return data

--- a/frontend/forms/widgets/findIdWidget.ts
+++ b/frontend/forms/widgets/findIdWidget.ts
@@ -211,11 +211,8 @@ export class AuthorIdentifierWidget extends FindIdWidget {
 	private onCheckboxChange(): void {
 		const currentValue = this.inputElement?.value ?? "";
 		if (this.isOrgCheckbox.checked) {
-			if (this.isOrcidUrl(currentValue)) {
-				this.isOrgCheckbox.checked = false;
-				return;
-			}
-			this.switchToRorMode(currentValue);
+			const valueForRor = this.isOrcidUrl(currentValue) ? "" : currentValue;
+			this.switchToRorMode(valueForRor);
 		} else {
 			this.switchToOrcidMode();
 		}

--- a/frontend/forms/widgets/findIdWidget.ts
+++ b/frontend/forms/widgets/findIdWidget.ts
@@ -116,7 +116,7 @@ export class OrcidWidget extends FindIdWidget {
 }
 
 export class DataciteDoiWidget extends FindIdWidget {
-	protected get placeholderExample(): string { 
+	protected get placeholderExample(): string {
 		return "https://doi.org/10.5281/zenodo.00000000";
 	}
 	protected override onFindButtonPressed(): void {
@@ -124,5 +124,148 @@ export class DataciteDoiWidget extends FindIdWidget {
 			.setTarget(this.parentField)
 			.withFilters(this.properties[propResultFilters]);
 		PopupDialogue.showPopup(popup);
+	}
+}
+
+export class AuthorIdentifierWidget extends FindIdWidget {
+
+	private isOrgCheckbox: HTMLInputElement = null;
+	private isOrgMode: boolean = false;
+
+	private static readonly ROR_PREFIX = "https://ror.org/";
+	private static readonly ROR_PATTERN = /^https?:\/\/ror\.org\//;
+	private static readonly ORCID_PATTERN = /^https?:\/\/orcid\.org\//;
+
+	private isRorUrl(url: string): boolean {
+		return AuthorIdentifierWidget.ROR_PATTERN.test(url);
+	}
+
+	private isOrcidUrl(url: string): boolean {
+		return AuthorIdentifierWidget.ORCID_PATTERN.test(url);
+	}
+
+	protected override get placeholderExample(): string {
+		return this.isOrgMode
+			? "https://ror.org/00000xxxx"
+			: "https://orcid.org/0000-0000-0000-0000";
+	}
+
+	protected override onFindButtonPressed(): void {
+		if (this.isOrgMode) {
+			const rorPopup = RorFinder.getInstance()
+				.setTarget(this.parentField)
+				.withFilters(this.properties[propResultFilters]);
+			PopupDialogue.showPopup(rorPopup);
+		} else {
+			const orcidPopup = OrcidFinder.getInstance()
+				.setTarget(this.parentField)
+				.withFilters(this.properties[propResultFilters]);
+			PopupDialogue.showPopup(orcidPopup);
+		}
+	}
+
+	override onDataSelected(data: JSONObject): void {
+		super.onDataSelected(data);
+		if (this.isOrgMode) return;
+
+		const field = this.parentField;
+		const siblings = field.parent?.getSubfields() ?? [];
+		let affiliationField: ModelMultiSubfield = null;
+		for (const sibling of siblings) {
+			if (sibling instanceof ModelMultiSubfield) affiliationField = sibling;
+		}
+		if (!affiliationField || affiliationField.hasValidInput()) return;
+
+		const orcidData = data as OrcidItem;
+		const affiliationNames = orcidData["institution-name"];
+		affiliationField.clearField();
+		for (const affilName of affiliationNames) {
+			const f = affiliationField.addNewMultifieldWithValue(affilName);
+			f.expandSubfields();
+		}
+	}
+
+	private buildCheckbox(readOnly: boolean): void {
+		const label = document.createElement("label");
+		label.style.display = "flex";
+		label.style.alignItems = "center";
+		label.style.gap = "0.35em";
+		label.style.fontSize = "0.85em";
+		label.style.marginBottom = "0.25em";
+		label.style.userSelect = "none";
+		label.style.cursor = "pointer";
+
+		this.isOrgCheckbox = document.createElement("input");
+		this.isOrgCheckbox.type = "checkbox";
+		this.isOrgCheckbox.disabled = readOnly;
+
+		label.appendChild(this.isOrgCheckbox);
+		label.appendChild(document.createTextNode("Is Organization"));
+		this.element.appendChild(label);
+
+		if (!readOnly) {
+			this.isOrgCheckbox.addEventListener("change", () => this.onCheckboxChange());
+		}
+	}
+
+	private onCheckboxChange(): void {
+		const currentValue = this.inputElement?.value ?? "";
+		if (this.isOrgCheckbox.checked) {
+			if (this.isOrcidUrl(currentValue)) {
+				this.isOrgCheckbox.checked = false;
+				return;
+			}
+			this.switchToRorMode(currentValue);
+		} else {
+			this.switchToOrcidMode();
+		}
+	}
+
+	private switchToRorMode(currentValue: string): void {
+		this.isOrgMode = true;
+		this.isOrgCheckbox.checked = true;
+		if (!currentValue) this.inputElement.value = AuthorIdentifierWidget.ROR_PREFIX;
+		this.inputElement.placeholder =
+			"Use 'find' button or paste URL (ex: " + this.placeholderExample + ")";
+		this.updateValidationState();
+	}
+
+	private switchToOrcidMode(): void {
+		this.isOrgMode = false;
+		this.isOrgCheckbox.checked = false;
+		const currentValue = this.inputElement?.value ?? "";
+		if (this.isRorUrl(currentValue)) this.inputElement.value = "";
+		this.inputElement.placeholder =
+			"Use 'find' button or paste URL (ex: " + this.placeholderExample + ")";
+		this.updateValidationState();
+	}
+
+	private updateValidationState(): void {
+		const value = this.inputElement?.value ?? "";
+		if (this.isOrgMode && value && !this.isRorUrl(value)) {
+			this.inputElement.setCustomValidity(
+				"Organization identifier must be a ROR URL (https://ror.org/...)"
+			);
+		} else {
+			this.inputElement.setCustomValidity("");
+		}
+	}
+
+	override setValue(value: string, notify: boolean = true): void {
+		super.setValue(value, notify);
+		if (!this.isOrgCheckbox) return;
+		if (this.isRorUrl(value)) this.switchToRorMode(value);
+		else if (this.isOrcidUrl(value)) this.switchToOrcidMode();
+	}
+
+	override initialize(readOnly: boolean = false): void {
+		this.buildCheckbox(readOnly);
+		super.initialize(readOnly);
+		this.inputElement.addEventListener("input", () => {
+			this.updateValidationState();
+			const val = this.inputElement.value;
+			if (this.isRorUrl(val) && !this.isOrgMode) this.switchToRorMode(val);
+			else if (this.isOrcidUrl(val) && this.isOrgMode) this.switchToOrcidMode();
+		});
 	}
 }

--- a/frontend/index.ts
+++ b/frontend/index.ts
@@ -2,16 +2,16 @@
  * entry point module for the website frontend logic
  */
 
-import { 
+import {
 	// widgets to initialize
-	CharWidget, NumberWidget, UrlWidget, EmailWidget, DateWidget, 
-	TextAreaWidget, CheckboxWidget, Widget, AutofillSomefWidget, 
+	CharWidget, NumberWidget, UrlWidget, EmailWidget, DateWidget,
+	TextAreaWidget, CheckboxWidget, Widget, AutofillSomefWidget,
 	ModelBox, FormGenerator, RorWidget, OrcidWidget, DataciteDoiWidget,
-	AutofillDataciteWidget, AutofillDialoge,
+	AutofillDataciteWidget, AutofillDialoge, AuthorIdentifierWidget,
 
 	// dialogues
 	RorFinder, OrcidFinder, DoiDataciteFinder,
-	ConfirmDialogue, TextInputDialogue, 
+	ConfirmDialogue, TextInputDialogue,
 } from "./loader";
 
 function initForms() {
@@ -28,6 +28,7 @@ function initForms() {
 		RorWidget,
 		OrcidWidget,
 		DataciteDoiWidget,
+		AuthorIdentifierWidget,
 		ModelBox,
 		AutofillSomefWidget,
 		AutofillDataciteWidget,


### PR DESCRIPTION
This PR implements the code changes necessary to allow submitters to submit a software package which has an author that is an organization instead of a person. This change is reflected in the JSON ld view of that package. Most of the code changes were to the frontend, but a few backend changes were needed in the software serializer as well. The changes are listed below:

- add frontend form generation functionality which adds an 'is organization' checkbox to the author field
- author search field now searches ROR database if the 'is organization' is checked instead of the orcid database
- ror/orcid url validation based on whether the 'is organization' box is checked
- drf software serializer has been modified to check if authors are organizations or people based on identifier url
- JSONLD format is now followed by specifying 'type' as 'organization' for organization authors, and affiliations are listed as 'parentOrganization' instead of 'affiliation'